### PR TITLE
Add compatibility for GHC 9.14 and 9.12

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,0 +1,82 @@
+name: build
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# INFO: The following configuration block ensures that only one build runs per branch,
+# which may be desirable for projects with a costly build process.
+# Remove this block from the CI workflow to let each CI job run to completion.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: GHC ${{ matrix.ghc-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        ghc-version: ['9.12', '9.10']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up GHC ${{ matrix.ghc-version }}
+        uses: haskell-actions/setup@v2
+        id: setup
+        with:
+          ghc-version: ${{ matrix.ghc-version }}
+          # Defaults, added for clarity:
+          cabal-version: 'latest'
+          cabal-update: true
+
+      - name: Configure the build
+        run: |
+          cabal configure --enable-tests --enable-benchmarks --disable-documentation
+          cabal build all --dry-run
+        # The last step generates dist-newstyle/cache/plan.json for the cache key.
+
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v4
+        id: cache
+        env:
+          key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ env.key }}-plan-${{ hashFiles('**/plan.json') }}
+          restore-keys: ${{ env.key }}-
+
+      - name: Install dependencies
+        # If we had an exact cache hit, the dependencies will be up to date.
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: cabal build all --only-dependencies
+
+      # Cache dependencies already here, so that we do not have to rebuild them should the subsequent steps fail.
+      - name: Save cached dependencies
+        uses: actions/cache/save@v4
+        # If we had an exact cache hit, trying to save the cache would error because of key clash.
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
+      - name: Build dependencies
+        run: cabal build all --only-dependencies
+
+      - name: Build `ghc-stack-profiler`
+        run: cabal build all
+
+      - name: Run tests
+        run: cabal test all
+
+    # There is more than one cabal file and currently we dont upload to hackage
+    #   - name: Check cabal file
+    #     run: cabal check
+
+      - name: Build documentation
+        run:
+          cabal haddock all

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -30,8 +30,7 @@ jobs:
         id: setup
         with:
           ghc-version: ${{ matrix.ghc-version }}
-          # Defaults, added for clarity:
-          cabal-version: 'latest'
+          cabal-version: '3.14.2.0'
           cabal-update: true
           ghcup-release-channel: https://raw.githubusercontent.com/haskell/ghcup-metadata/refs/heads/develop/ghcup-prereleases-0.0.9.yaml
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ghc-version: ['9.12', '9.10']
+        ghc-version: ['9.14.0', '9.12', '9.10']
 
     steps:
       - uses: actions/checkout@v4
@@ -33,6 +33,7 @@ jobs:
           # Defaults, added for clarity:
           cabal-version: 'latest'
           cabal-update: true
+          ghcup-release-channel: https://raw.githubusercontent.com/haskell/ghcup-metadata/refs/heads/develop/ghcup-prereleases-0.0.9.yaml
 
       - name: Configure the build
         run: |

--- a/cabal.project
+++ b/cabal.project
@@ -6,3 +6,8 @@ packages:
 
 package *
     ghc-options: -finfo-table-map -fdistinct-constructor-tables
+
+source-repository-package
+    type: git
+    location: https://github.com/fendor/ghc-stack-annotations.git
+    tag: 0667af1cec1b20ba7fed4a5de675afe81a8ae07d

--- a/cabal.project
+++ b/cabal.project
@@ -11,3 +11,10 @@ source-repository-package
     type: git
     location: https://github.com/fendor/ghc-stack-annotations.git
     tag: 0667af1cec1b20ba7fed4a5de675afe81a8ae07d
+
+if impl(ghc >=9.14)
+    allow-newer:
+        base,
+        template-haskell,
+        ghc-bignum,
+        containers,

--- a/examples/simple/app/Main.hs
+++ b/examples/simple/app/Main.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS -fno-omit-yields #-}
 module Main where
 
-import GHC.Stack.Annotation.Experimental
+import GHC.Stack.Annotation
 import GHC.Stack.Profiler.Sampler
 
 main :: IO ()

--- a/examples/simple/simple.cabal
+++ b/examples/simple/simple.cabal
@@ -18,6 +18,6 @@ executable simple
     build-depends:
         base,
         ghc-stack-profiler,
-        ghc-experimental,
+        ghc-stack-annotations,
     hs-source-dirs:   app
     default-language: Haskell2010

--- a/ghc-stack-profiler-core/ghc-stack-profiler-core.cabal
+++ b/ghc-stack-profiler-core/ghc-stack-profiler-core.cabal
@@ -6,6 +6,7 @@ author: Hannes Siebenhandl, Wen Kokke, Matthew Pickering
 maintainer: hannes@well-typed.com
 build-type: Simple
 extra-doc-files: CHANGELOG.md
+tested-with: GHC ==9.14 || ==9.12 || ==9.10
 
 common warnings
   ghc-options:
@@ -26,11 +27,11 @@ library
     warnings, exts
 
   exposed-modules:
-    GHC.Stack.Profiler.Eventlog
-    GHC.Stack.Profiler.SourceLocation
-    GHC.Stack.Profiler.SymbolTable
-    GHC.Stack.Profiler.ThreadSample
-    GHC.Stack.Profiler.Util
+    GHC.Stack.Profiler.Core.Eventlog
+    GHC.Stack.Profiler.Core.SourceLocation
+    GHC.Stack.Profiler.Core.SymbolTable
+    GHC.Stack.Profiler.Core.ThreadSample
+    GHC.Stack.Profiler.Core.Util
 
   build-depends:
     base,

--- a/ghc-stack-profiler-core/src/GHC/Stack/Profiler/Core/Eventlog.hs
+++ b/ghc-stack-profiler-core/src/GHC/Stack/Profiler/Core/Eventlog.hs
@@ -1,4 +1,4 @@
-module GHC.Stack.Profiler.Eventlog where
+module GHC.Stack.Profiler.Core.Eventlog where
 
 import Control.Monad (replicateM)
 import Data.Binary
@@ -7,7 +7,7 @@ import qualified Data.List as List
 import Data.Text (Text)
 import GHC.Generics
 
-import GHC.Stack.Profiler.Util
+import GHC.Stack.Profiler.Core.Util
 
 -- ----------------------------------------------------------------------------
 -- Eventlog Messages
@@ -43,6 +43,7 @@ data BinaryEventlogMessage
   | CallStackChunk !BinaryCallStackMessage
   | StringDef !BinaryStringMessage
   | SourceLocationDef !BinarySourceLocationMessage
+  deriving (Eq, Ord, Show, Generic)
 
 data BinaryCallStackMessage = MkBinaryCallStackMessage
   { binaryCallThreadId :: !Word64

--- a/ghc-stack-profiler-core/src/GHC/Stack/Profiler/Core/SourceLocation.hs
+++ b/ghc-stack-profiler-core/src/GHC/Stack/Profiler/Core/SourceLocation.hs
@@ -1,4 +1,4 @@
-module GHC.Stack.Profiler.SourceLocation where
+module GHC.Stack.Profiler.Core.SourceLocation where
 
 import Data.Word (Word32)
 import Data.Text (Text)

--- a/ghc-stack-profiler-core/src/GHC/Stack/Profiler/Core/ThreadSample.hs
+++ b/ghc-stack-profiler-core/src/GHC/Stack/Profiler/Core/ThreadSample.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module GHC.Stack.Profiler.ThreadSample (
+module GHC.Stack.Profiler.Core.ThreadSample (
   ThreadSample(..),
   deserializeEventlogMessage,
 
@@ -30,10 +30,10 @@ import qualified Data.Text as Text
 import GHC.Generics
 
 import GHC.Stack.CloneStack (StackSnapshot)
-import GHC.Stack.Profiler.Eventlog
-import GHC.Stack.Profiler.Util
-import GHC.Stack.Profiler.SourceLocation
-import GHC.Stack.Profiler.SymbolTable
+import GHC.Stack.Profiler.Core.Eventlog
+import GHC.Stack.Profiler.Core.Util
+import GHC.Stack.Profiler.Core.SourceLocation
+import GHC.Stack.Profiler.Core.SymbolTable
 
 -- ----------------------------------------------------------------------------
 -- Thread Sample

--- a/ghc-stack-profiler-core/src/GHC/Stack/Profiler/Core/Util.hs
+++ b/ghc-stack-profiler-core/src/GHC/Stack/Profiler/Core/Util.hs
@@ -1,4 +1,4 @@
-module GHC.Stack.Profiler.Util where
+module GHC.Stack.Profiler.Core.Util where
 
 import Control.Monad (replicateM)
 import Data.Binary
@@ -28,7 +28,7 @@ getTextWord16 = do
   pure $ Text.pack s
 
 showAsHex :: Integral a => a -> String
-showAsHex d = Numeric.showHex d ""
+showAsHex d = "0x" ++ Numeric.showHex d ""
 
 putWord64 :: Word64 -> Put
 putWord64 = putWord64be

--- a/ghc-stack-profiler-speedscope/ghc-stack-profiler-speedscope.cabal
+++ b/ghc-stack-profiler-speedscope/ghc-stack-profiler-speedscope.cabal
@@ -6,6 +6,7 @@ author: Hannes Siebenhandl, Wen Kokke, Matthew Pickering
 maintainer: hannes@well-typed.com
 build-type: Simple
 extra-doc-files: CHANGELOG.md
+tested-with: GHC ==9.14 || ==9.12 || ==9.10
 
 common warnings
   ghc-options:

--- a/ghc-stack-profiler-speedscope/src/GHC/Stack/Profiler/Speedscope.hs
+++ b/ghc-stack-profiler-speedscope/src/GHC/Stack/Profiler/Speedscope.hs
@@ -32,10 +32,10 @@ import Data.IntMap (IntMap)
 import qualified Data.IntMap.Strict as IntMap
 import Data.Coerce (coerce)
 
-import GHC.Stack.Profiler.ThreadSample as ThreadSample
-import GHC.Stack.Profiler.Util
-import GHC.Stack.Profiler.Eventlog
-import GHC.Stack.Profiler.SymbolTable
+import GHC.Stack.Profiler.Core.ThreadSample as ThreadSample
+import GHC.Stack.Profiler.Core.Util
+import GHC.Stack.Profiler.Core.Eventlog
+import GHC.Stack.Profiler.Core.SymbolTable
 
 data SSOptions = SSOptions
   { file :: FilePath

--- a/ghc-stack-profiler/cbits/Stack.cmm
+++ b/ghc-stack-profiler/cbits/Stack.cmm
@@ -1,0 +1,191 @@
+// ////////////////////////////////////////////////////////////////////////////
+//
+// DO NOT MODIFY THIS FILE
+//
+// It has been copy pasted from
+// https://gitlab.haskell.org/ghc/ghc/-/blob/ac7b737e8da74b2508994867ede0becb387cfc47/libraries/ghc-internal/cbits/Stack.cmm
+//
+// ////////////////////////////////////////////////////////////////////////////
+
+// Uncomment to enable assertions during development
+// #define DEBUG 1
+
+#include "Cmm.h"
+
+// StgStack_marking was not available in the Stage0 compiler at the time of
+// writing. Because, it has been added to derivedConstants when Stack.cmm was
+// developed.
+#if defined(StgStack_marking)
+
+// Returns the next stackframe's StgStack* and offset in it. And, an indicator
+// if this frame is the last one (`hasNext` bit.)
+// (StgStack*, StgWord, StgWord) advanceStackFrameLocationzh(StgStack* stack, StgWord offsetWords)
+advanceStackFrameLocationzh (P_ stack, W_ offsetWords) {
+  W_ frameSize;
+  (frameSize) = ccall stackFrameSize(stack, offsetWords);
+
+  P_ nextClosurePtr;
+  nextClosurePtr = (StgStack_sp(stack) + WDS(offsetWords) + WDS(frameSize));
+
+  P_ stackArrayPtr;
+  stackArrayPtr = stack + SIZEOF_StgHeader + OFFSET_StgStack_stack;
+
+  P_ stackBottom;
+  W_ stackSize, stackSizeInBytes;
+  stackSize = TO_W_(StgStack_stack_size(stack));
+  stackSizeInBytes = WDS(stackSize);
+  stackBottom = stackSizeInBytes + stackArrayPtr;
+
+  P_ newStack;
+  W_ newOffsetWords, hasNext;
+  if(nextClosurePtr < stackBottom) (likely: True) {
+    newStack = stack;
+    newOffsetWords = offsetWords + frameSize;
+    hasNext = 1;
+  } else {
+    P_ underflowFrameStack;
+    (underflowFrameStack) = ccall getUnderflowFrameStack(stack, offsetWords);
+    if (underflowFrameStack == NULL) (likely: True) {
+      newStack = NULL;
+      newOffsetWords = NULL;
+      hasNext = NULL;
+    } else {
+      newStack = underflowFrameStack;
+      newOffsetWords = NULL;
+      hasNext = 1;
+    }
+  }
+
+  return (newStack, newOffsetWords, hasNext);
+}
+
+// (StgWord, StgWord) getSmallBitmapzh(StgStack* stack, StgWord offsetWords)
+getSmallBitmapzh(P_ stack, W_ offsetWords) {
+  P_ c;
+  c = StgStack_sp(stack) + WDS(offsetWords);
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(c));
+
+  W_ bitmap, size;
+  (bitmap) = ccall getBitmapWord(c);
+  (size) = ccall getBitmapSize(c);
+
+  return (bitmap, size);
+}
+
+
+// (StgWord, StgWord) getRetFunSmallBitmapzh(StgStack* stack, StgWord offsetWords)
+getRetFunSmallBitmapzh(P_ stack, W_ offsetWords) {
+  P_ c;
+  c = StgStack_sp(stack) + WDS(offsetWords);
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(c));
+
+  W_ bitmap, size, specialType;
+  (bitmap) = ccall getRetFunBitmapWord(c);
+  (size) = ccall getRetFunBitmapSize(c);
+
+  return (bitmap, size);
+}
+
+// (StgWord*, StgWord) getLargeBitmapzh(StgStack* stack, StgWord offsetWords)
+getLargeBitmapzh(P_ stack, W_ offsetWords) {
+  P_ c, words;
+  W_ size;
+  c = StgStack_sp(stack) + WDS(offsetWords);
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(c));
+
+  (words) = ccall getLargeBitmap(MyCapability(), c);
+  (size) = ccall getLargeBitmapSize(c);
+
+  return (words, size);
+}
+
+// (StgWord*, StgWord) getBCOLargeBitmapzh(StgStack* stack, StgWord offsetWords)
+getBCOLargeBitmapzh(P_ stack, W_ offsetWords) {
+  P_ c, words;
+  W_ size;
+  c = StgStack_sp(stack) + WDS(offsetWords);
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(c));
+
+  (words) = ccall getBCOLargeBitmap(MyCapability(), c);
+  (size) = ccall getBCOLargeBitmapSize(c);
+
+  return (words, size);
+}
+
+// (StgWord*, StgWord) getRetFunLargeBitmapzh(StgStack* stack, StgWord offsetWords)
+getRetFunLargeBitmapzh(P_ stack, W_ offsetWords) {
+  P_ c, words;
+  W_ size;
+  c = StgStack_sp(stack) + WDS(offsetWords);
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(c));
+
+  (words) = ccall getRetFunLargeBitmap(MyCapability(), c);
+  (size) = ccall getRetFunSize(c);
+
+  return (words, size);
+}
+
+// (StgWord) getWordzh(StgStack* stack, StgWord offsetWords)
+getWordzh(P_ stack, W_ offsetWords) {
+  P_ wordAddr;
+  wordAddr = (StgStack_sp(stack) + WDS(offsetWords));
+  return (W_[wordAddr]);
+}
+
+// (StgStack*) getUnderflowFrameNextChunkzh(StgStack* stack, StgWord offsetWords)
+getUnderflowFrameNextChunkzh(P_ stack, W_ offsetWords) {
+  P_ closurePtr;
+  closurePtr = (StgStack_sp(stack) + WDS(offsetWords));
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(closurePtr));
+
+  P_ next_chunk;
+  (next_chunk) = ccall getUnderflowFrameNextChunk(closurePtr);
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(next_chunk));
+  return (next_chunk);
+}
+
+// (StgWord) getRetFunTypezh(StgStack* stack, StgWord offsetWords)
+isArgGenBigRetFunTypezh(P_ stack, W_ offsetWords) {
+  P_ c;
+  c = StgStack_sp(stack) + WDS(offsetWords);
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(c));
+
+  W_ type;
+  (type) = ccall isArgGenBigRetFunType(c);
+  return (type);
+}
+
+// (StgInfoTable*, StgInfoTable*) getInfoTableAddrszh(StgStack* stack, StgWord offsetWords)
+getInfoTableAddrszh(P_ stack, W_ offsetWords) {
+  P_ p, info_struct, info_ptr_ipe_key;
+  p = StgStack_sp(stack) + WDS(offsetWords);
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(p));
+  info_struct = %GET_STD_INFO(UNTAG(p));
+  info_ptr_ipe_key = %INFO_PTR(UNTAG(p));
+  return (info_struct, info_ptr_ipe_key);
+}
+
+// (StgInfoTable*) getStackInfoTableAddrzh(StgStack* stack)
+getStackInfoTableAddrzh(P_ stack) {
+  P_ info;
+  info = %GET_STD_INFO(UNTAG(stack));
+  return (info);
+}
+
+// (StgClosure*) getStackClosurezh(StgStack* stack, StgWord offsetWords)
+getStackClosurezh(P_ stack, W_ offsetWords) {
+  P_ ptr;
+  ptr = StgStack_sp(stack) + WDS(offsetWords);
+
+  P_ closure;
+  (closure) = ccall getStackClosure(ptr);
+  return (closure);
+}
+
+// (bits32) getStackFieldszh(StgStack* stack)
+getStackFieldszh(P_ stack){
+  bits32 size;
+  size = StgStack_stack_size(stack);
+  return (size);
+}
+#endif

--- a/ghc-stack-profiler/cbits/Stack_c.c
+++ b/ghc-stack-profiler/cbits/Stack_c.c
@@ -1,0 +1,159 @@
+// ////////////////////////////////////////////////////////////////////////////
+//
+// DO NOT MODIFY THIS FILE
+//
+// It has been copy pasted from
+// https://gitlab.haskell.org/ghc/ghc/-/blob/ac7b737e8da74b2508994867ede0becb387cfc47/libraries/ghc-internal/cbits/Stack_c.c
+//
+// ////////////////////////////////////////////////////////////////////////////
+#include "MachDeps.h"
+#include "Rts.h"
+#include "RtsAPI.h"
+#include "rts/Messages.h"
+#include "rts/Types.h"
+#include "rts/storage/ClosureTypes.h"
+#include "rts/storage/Closures.h"
+#include "rts/storage/FunTypes.h"
+#include "rts/storage/InfoTables.h"
+
+StgWord stackFrameSize(StgStack *stack, StgWord offset) {
+  StgClosure *c = (StgClosure *)(stack->sp + offset);
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(c));
+  return stack_frame_sizeW(c);
+}
+
+StgStack *getUnderflowFrameStack(StgStack *stack, StgWord offset) {
+  StgClosure *frame = (StgClosure *)(stack->sp + offset);
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(frame));
+  const StgRetInfoTable *info = get_ret_itbl((StgClosure *)frame);
+
+  if (info->i.type == UNDERFLOW_FRAME) {
+    return ((StgUnderflowFrame *)frame)->next_chunk;
+  } else {
+    return NULL;
+  }
+}
+
+// Only exists to make the get_itbl macro available in Haskell code (via FFI).
+const StgInfoTable *getItbl(StgClosure *closure) {
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(closure));
+  return get_itbl(closure);
+}
+
+StgWord getBitmapSize(StgClosure *c) {
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(c));
+
+  const StgInfoTable *info = get_itbl(c);
+  StgWord bitmap = info->layout.bitmap;
+  return BITMAP_SIZE(bitmap);
+}
+
+StgWord getRetFunBitmapSize(StgRetFun *ret_fun) {
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(ret_fun));
+
+  const StgFunInfoTable *fun_info = get_fun_itbl(UNTAG_CLOSURE(ret_fun->fun));
+  switch (fun_info->f.fun_type) {
+  case ARG_GEN:
+    return BITMAP_SIZE(fun_info->f.b.bitmap);
+  case ARG_GEN_BIG:
+    return GET_FUN_LARGE_BITMAP(fun_info)->size;
+  default:
+    return BITMAP_SIZE(stg_arg_bitmaps[fun_info->f.fun_type]);
+  }
+}
+
+StgWord getBitmapWord(StgClosure *c) {
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(c));
+
+  const StgInfoTable *info = get_itbl(c);
+  StgWord bitmap = info->layout.bitmap;
+  StgWord bitmapWord = BITMAP_BITS(bitmap);
+  return bitmapWord;
+}
+
+StgWord getRetFunBitmapWord(StgRetFun *ret_fun) {
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(ret_fun));
+
+  const StgFunInfoTable *fun_info = get_fun_itbl(UNTAG_CLOSURE(ret_fun->fun));
+  fun_info = get_fun_itbl(UNTAG_CLOSURE(ret_fun->fun));
+  switch (fun_info->f.fun_type) {
+  case ARG_GEN:
+    return BITMAP_BITS(fun_info->f.b.bitmap);
+  case ARG_GEN_BIG:
+    // Cannot do more than warn and exit.
+    errorBelch("Unexpected ARG_GEN_BIG StgRetFun closure %p", ret_fun);
+    stg_exit(EXIT_INTERNAL_ERROR);
+  default:
+    return BITMAP_BITS(stg_arg_bitmaps[fun_info->f.fun_type]);
+  }
+}
+
+StgWord getLargeBitmapSize(StgClosure *c) {
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(c));
+
+  const StgInfoTable *info = get_itbl(c);
+  StgLargeBitmap *bitmap = GET_LARGE_BITMAP(info);
+  return bitmap->size;
+}
+
+StgWord getRetFunSize(StgRetFun *ret_fun) {
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(ret_fun));
+
+  const StgFunInfoTable *fun_info = get_fun_itbl(UNTAG_CLOSURE(ret_fun->fun));
+  fun_info = get_fun_itbl(UNTAG_CLOSURE(ret_fun->fun));
+  switch (fun_info->f.fun_type) {
+  case ARG_GEN:
+    return BITMAP_SIZE(fun_info->f.b.bitmap);
+  case ARG_GEN_BIG:
+    return GET_FUN_LARGE_BITMAP(fun_info)->size;
+  default:
+    return BITMAP_SIZE(stg_arg_bitmaps[fun_info->f.fun_type]);
+  }
+}
+
+StgWord getBCOLargeBitmapSize(StgClosure *c) {
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(c));
+
+  StgBCO *bco = (StgBCO *)*c->payload;
+
+  return BCO_BITMAP_SIZE(bco);
+}
+
+StgWord *getLargeBitmap(Capability *cap, StgClosure *c) {
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(c));
+  const StgInfoTable *info = get_itbl(c);
+  StgLargeBitmap *bitmap = GET_LARGE_BITMAP(info);
+
+  return bitmap->bitmap;
+}
+
+StgWord *getRetFunLargeBitmap(Capability *cap, StgRetFun *ret_fun) {
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(ret_fun));
+
+  const StgFunInfoTable *fun_info = get_fun_itbl(UNTAG_CLOSURE(ret_fun->fun));
+  StgLargeBitmap *bitmap = GET_FUN_LARGE_BITMAP(fun_info);
+
+  return bitmap->bitmap;
+}
+
+StgWord *getBCOLargeBitmap(Capability *cap, StgClosure *c) {
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(c));
+
+  StgBCO *bco = (StgBCO *)*c->payload;
+  StgLargeBitmap *bitmap = BCO_BITMAP(bco);
+
+  return bitmap->bitmap;
+}
+
+StgStack *getUnderflowFrameNextChunk(StgUnderflowFrame *frame) {
+  return frame->next_chunk;
+}
+
+StgWord isArgGenBigRetFunType(StgRetFun *ret_fun) {
+  ASSERT(LOOKS_LIKE_CLOSURE_PTR(ret_fun));
+
+  const StgFunInfoTable *fun_info = get_fun_itbl(UNTAG_CLOSURE(ret_fun->fun));
+  return fun_info->f.fun_type == ARG_GEN_BIG;
+}
+
+StgClosure *getStackClosure(StgClosure **c) { return *c; }

--- a/ghc-stack-profiler/ghc-stack-profiler.cabal
+++ b/ghc-stack-profiler/ghc-stack-profiler.cabal
@@ -6,6 +6,7 @@ author: Hannes Siebenhandl, Wen Kokke, Matthew Pickering
 maintainer: hannes@well-typed.com
 build-type: Simple
 extra-doc-files: CHANGELOG.md
+tested-with: GHC ==9.14 || ==9.12 || ==9.10
 
 common warnings
   ghc-options:
@@ -20,6 +21,7 @@ common exts
     LambdaCase
     DerivingStrategies
     DeriveGeneric
+    PatternSynonyms
 
 flag use-ghc-trace-events
   description: Use the package 'ghc-trace-events'
@@ -32,17 +34,32 @@ library
 
   exposed-modules:
     Debug.Trace.Binary.Compat
+    GHC.Internal.ClosureTypes.Compat
+    GHC.Internal.Heap.Closures.Compat
+    GHC.Internal.InfoProv.Types.Compat
+    GHC.Internal.Stack.Decode.Compat
+    GHC.Internal.Stack.Constants.Compat
+    GHC.Stack.Annotation.Experimental.Compat
     GHC.Stack.Profiler.Decode
     GHC.Stack.Profiler.Sampler
+    GHC.Stack.Profiler.Stack.Compat
+    GHC.Stack.Profiler.Stack.Decode
+    GHC.Stack.Profiler.Util
+
+  autogen-modules:
+    GHC.Internal.InfoProv.Types.Compat
 
   build-depends:
     base,
     binary,
     bytestring,
-    ghc-experimental,
     ghc-internal,
     ghc-stack-profiler-core,
     text,
+    ghc-heap,
+
+  if impl(ghc >= 9.14)
+    build-depends: ghc-experimental,
 
   if flag(use-ghc-trace-events)
     cpp-options:
@@ -52,6 +69,12 @@ library
   else
     build-depends:
         ghc-prim,
+
+  if impl(ghc < 9.14)
+    cmm-sources:
+      cbits/Stack.cmm
+    c-sources:
+      cbits/Stack_c.c
 
   hs-source-dirs:
     src

--- a/ghc-stack-profiler/src/GHC/Internal/ClosureTypes/Compat.hs
+++ b/ghc-stack-profiler/src/GHC/Internal/ClosureTypes/Compat.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE CPP  #-}
+module GHC.Internal.ClosureTypes.Compat (
+  ClosureType(..),
+#if !MIN_VERSION_ghc_internal(9,1400,0)
+  pattern ANN_FRAME,
+#endif
+) where
+
+import GHC.Internal.ClosureTypes
+
+#if !MIN_VERSION_ghc_internal(9,1400,0)
+-- Unmatchable, as ANN_FRAME is a stack frame type introduced in GHC 9.14
+pattern ANN_FRAME :: ClosureType
+pattern ANN_FRAME <- (const Nothing -> Just _)
+#endif

--- a/ghc-stack-profiler/src/GHC/Internal/Heap/Closures/Compat.hs
+++ b/ghc-stack-profiler/src/GHC/Internal/Heap/Closures/Compat.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE CPP #-}
+module GHC.Internal.Heap.Closures.Compat (
+  Box(..),
+) where
+
+#if MIN_VERSION_ghc_internal(9,1400,0)
+import GHC.Internal.Heap.Closures ( Box(..) )
+#else
+import GHC.Exts.Heap.Closures ( Box(..) )
+#endif

--- a/ghc-stack-profiler/src/GHC/Internal/InfoProv/Types/Compat.hsc
+++ b/ghc-stack-profiler/src/GHC/Internal/InfoProv/Types/Compat.hsc
@@ -1,0 +1,42 @@
+{-# LANGUAGE CApiFFI #-}
+{-# LANGUAGE CPP     #-}
+#include "Rts.h"
+
+module GHC.Internal.InfoProv.Types.Compat (
+    lookupIpeId
+) where
+
+import Data.Word
+import Foreign.Ptr
+import Foreign.Marshal.Alloc
+import Foreign.C.Types
+#if MIN_VERSION_ghc_internal(9,1500,0)
+import Foreign.Storable (peekByteOff)
+#else
+import GHC.Stack.Profiler.Util (castPtrToWord64)
+#endif
+
+import qualified GHC.Internal.InfoProv.Types as InfoProv
+
+foreign import ccall "lookupIPE" c_lookupIPE ::
+  Ptr InfoProv.StgInfoTable ->
+  Ptr InfoProv.InfoProvEnt ->
+  IO CBool
+
+lookupIpeId :: Ptr InfoProv.StgInfoTable -> IO (Maybe Word64)
+lookupIpeId itbl =
+  allocaBytes (#size InfoProvEnt) $ \p -> do
+    res <- c_lookupIPE itbl p
+    case res of
+      1 ->
+#if MIN_VERSION_ghc_internal(9,1500,0)
+        Just `fmap` peekIpProvId (InfoProv.ipeProv p)
+#else
+        pure $ Just $ castPtrToWord64 itbl
+#endif
+      _ -> return Nothing
+
+#if MIN_VERSION_ghc_internal(9,1500,0)
+peekIpProvId :: Ptr InfoProv.InfoProv -> IO Word64
+peekIpProvId p  =  (# peek InfoProv, info_prov_id) p
+#endif

--- a/ghc-stack-profiler/src/GHC/Internal/Stack/Constants/Compat.hs
+++ b/ghc-stack-profiler/src/GHC/Internal/Stack/Constants/Compat.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE CPP #-}
+module GHC.Internal.Stack.Constants.Compat (
+  WordOffset(..),
+  offsetStgAnnFrameAnn,
+) where
+
+#if MIN_VERSION_ghc_internal(9,1400,0)
+#if defined(PROFILING)
+import GHC.Internal.Stack.ConstantsProf
+#else
+import GHC.Internal.Stack.Constants
+#endif
+#else
+import GHC.Exts.Stack.Constants
+
+offsetStgAnnFrameAnn :: WordOffset
+offsetStgAnnFrameAnn = error "offsetStgAnnFrameAnn is only available in GHC >=9.14"
+#endif
+

--- a/ghc-stack-profiler/src/GHC/Internal/Stack/Decode/Compat.hs
+++ b/ghc-stack-profiler/src/GHC/Internal/Stack/Decode/Compat.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE GHCForeignImportPrim #-}
+{-# LANGUAGE UnliftedFFITypes #-}
+{-# LANGUAGE CPP #-}
+module GHC.Internal.Stack.Decode.Compat (
+  StackFrameLocation,
+  StackSnapshot#,
+  StackInfoTable(..),
+  getInfoTableForStack,
+  getInfoTableOnStack,
+  advanceStackFrameLocation,
+  stackHead,
+  Box(..),
+  getClosureBox,
+) where
+
+import GHC.Exts
+import GHC.Stack.CloneStack (StackSnapshot (..))
+-- See Note [No way-dependent imports]
+#if defined(PROFILING)
+import GHC.Exts.Heap.InfoTableProf
+#else
+import GHC.Exts.Heap.InfoTable
+#endif
+import qualified GHC.Internal.InfoProv.Types as InfoProv
+import GHC.Internal.Heap.Closures.Compat
+import GHC.Internal.Stack.Constants.Compat (WordOffset)
+
+{-
+Note [No way-dependent imports]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`ghc -M` currently assumes that the imports for a module are the same
+in every way.  This is arguably a bug, but breaking this assumption by
+importing different things in different ways can cause trouble.  For
+example, this module in the profiling way imports and uses
+GHC.Exts.Heap.InfoTableProf.  When it was not also imported in the
+vanilla way, there were intermittent build failures due to this module
+being compiled in the profiling way before GHC.Exts.Heap.InfoTableProf
+in the profiling way. (#15197)
+-}
+
+type StackFrameLocation = (StackSnapshot, WordOffset)
+
+data StackInfoTable = StackInfoTable
+  { infoTableStructPtr :: Ptr InfoProv.StgInfoTable
+  , infoTablePtr :: Ptr InfoProv.StgInfoTable
+  , infoTable :: StgInfoTable
+  }
+
+-- | Get the 'StgInfoTable' of the stack frame.
+-- Additionally, provides 'InfoProv' for the 'StgInfoTable' if there is any.
+getInfoTableOnStack :: StackSnapshot# -> WordOffset -> IO StackInfoTable
+getInfoTableOnStack stackSnapshot# index = do
+  let !(# itbl_struct#, itbl_ptr_ipe_key# #) = getInfoTableAddrs# stackSnapshot# (wordOffsetToWord# index)
+      itbl_struct = Ptr itbl_struct#
+      itbl_ptr = Ptr itbl_ptr_ipe_key#
+
+  itbl <- peekItbl itbl_struct
+  pure StackInfoTable
+    { infoTableStructPtr = itbl_struct
+    , infoTablePtr = itbl_ptr
+    , infoTable = itbl
+    }
+
+getInfoTableForStack :: StackSnapshot# -> IO StgInfoTable
+getInfoTableForStack stackSnapshot# =
+  peekItbl $
+    Ptr (getStackInfoTableAddr# stackSnapshot#)
+
+-- | Advance to the next stack frame (if any)
+advanceStackFrameLocation :: StackFrameLocation -> Maybe StackFrameLocation
+advanceStackFrameLocation (StackSnapshot stackSnapshot#, index) =
+  let !(# s', i', hasNext #) = advanceStackFrameLocation# stackSnapshot# (wordOffsetToWord# index)
+   in if I# hasNext > 0
+        then Just (StackSnapshot s', primWordToWordOffset i')
+        else Nothing
+  where
+    primWordToWordOffset :: Word# -> WordOffset
+    primWordToWordOffset w# = fromIntegral (W# w#)
+
+-- | `StackFrameLocation` of the top-most stack frame
+stackHead :: StackSnapshot# -> StackFrameLocation
+stackHead s# = (StackSnapshot s#, 0) -- GHC stacks are never empty
+
+getClosureBox :: StackSnapshot# -> WordOffset -> Box
+getClosureBox stackSnapshot# index =
+  case getStackClosure# stackSnapshot# (wordOffsetToWord# index) of
+    -- c needs to be strictly evaluated, otherwise a thunk gets boxed (and
+    -- will later be decoded as such)
+    !c -> Box c
+
+-- | Advance to the next stack frame (if any)
+--
+-- The last `Int#` in the result tuple is meant to be treated as bool
+-- (has_next).
+foreign import prim "advanceStackFrameLocationzh"
+  advanceStackFrameLocation# :: StackSnapshot# -> Word# -> (# StackSnapshot#, Word#, Int# #)
+
+foreign import prim "getInfoTableAddrszh"
+  getInfoTableAddrs# :: StackSnapshot# -> Word# -> (# Addr#, Addr# #)
+
+foreign import prim "getStackInfoTableAddrzh"
+  getStackInfoTableAddr# :: StackSnapshot# -> Addr#
+
+foreign import prim "getStackClosurezh"
+  getStackClosure# :: StackSnapshot# -> Word# ->  Any
+
+-- ----------------------------------------------------------------------------
+-- Utilities that really should live somewhere else
+-- ----------------------------------------------------------------------------
+
+-- | Unbox 'Int#' from 'Int'
+toInt# :: Int -> Int#
+toInt# (I# i) = i
+
+-- | Convert `Int` to `Word#`
+intToWord# :: Int -> Word#
+intToWord# i = int2Word# (toInt# i)
+
+wordOffsetToWord# :: WordOffset -> Word#
+wordOffsetToWord# wo = intToWord# (fromIntegral wo)

--- a/ghc-stack-profiler/src/GHC/Stack/Annotation/Experimental/Compat.hs
+++ b/ghc-stack-profiler/src/GHC/Stack/Annotation/Experimental/Compat.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE GADTs #-}
+module GHC.Stack.Annotation.Experimental.Compat (
+  SomeStackAnnotation(..),
+  CallStackAnnotation(..),
+  StringAnnotation(..),
+) where
+
+#if MIN_VERSION_ghc_internal(9,1400,0)
+import GHC.Stack.Annotation.Experimental
+#else
+import Data.Typeable
+import GHC.Stack.Types (CallStack)
+
+data SomeStackAnnotation where
+  SomeStackAnnotation :: forall a. (Typeable a) => a -> SomeStackAnnotation
+
+data StringAnnotation where
+  StringAnnotation :: String -> StringAnnotation
+
+newtype CallStackAnnotation = CallStackAnnotation CallStack
+#endif

--- a/ghc-stack-profiler/src/GHC/Stack/Profiler/Decode.hs
+++ b/ghc-stack-profiler/src/GHC/Stack/Profiler/Decode.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE MagicHash #-}
 module GHC.Stack.Profiler.Decode (
   SymbolTable,
   serializeThreadSample,
@@ -9,25 +8,15 @@ import Data.Binary
 import Data.Binary.Put
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
-import qualified Data.Text as Text
-import Data.Typeable (cast)
-import Data.Maybe
 import qualified Data.List.NonEmpty as NonEmpty
-import Unsafe.Coerce
 import Data.Tuple
 
-import GHC.Stack.Annotation.Experimental
-import GHC.Stack.CloneStack (StackSnapshot(..))
 import GHC.Internal.Conc.Sync
-import GHC.Internal.InfoProv.Types (lookupIpProvId)
-import GHC.Internal.Heap.Closures
-import qualified GHC.Internal.Stack.Decode as Decode
-import GHC.Internal.Stack.Types
 
-import GHC.Stack.Profiler.SymbolTable
-import GHC.Stack.Profiler.ThreadSample
-import GHC.Stack.Profiler.Eventlog
-import GHC.Stack.Profiler.Util
+import GHC.Stack.Profiler.Core.SymbolTable
+import GHC.Stack.Profiler.Core.ThreadSample
+import GHC.Stack.Profiler.Core.Eventlog
+import GHC.Stack.Profiler.Stack.Decode (decodeStackWithIpProvId)
 
 type SymbolTable = SymbolTableWriter MapTable
 
@@ -39,7 +28,8 @@ serializeThreadSample tableRef sample = do
 threadSampleToCallStackMessage :: IORef SymbolTable -> ThreadSample -> IO [BinaryEventlogMessage]
 threadSampleToCallStackMessage tableRef sample = do
   frames <- decodeStackWithIpProvId $ threadSampleStackSnapshot sample
-  let callStackItems = fmap NonEmpty.head . NonEmpty.group $ mapMaybe (uncurry stackFrameToStackItem) frames
+  -- removes immediate duplicates
+  let callStackItems = fmap NonEmpty.head $ NonEmpty.group frames
   let callStackMessage = MkCallStackMessage
         { callThreadId = fromThreadId $ threadSampleId sample
         , callCapabilityId = threadSampleCapability sample
@@ -48,59 +38,3 @@ threadSampleToCallStackMessage tableRef sample = do
   -- TODO: Abstract IORef SymbolTable somehow
   atomicModifyIORef' tableRef $ \ table ->
     swap $ dehydrateCallStackMessage table callStackMessage
-
-decodeStackWithIpProvId :: StackSnapshot -> IO [(StackFrame, Maybe Word64)]
-decodeStackWithIpProvId snapshot = do
-  snd <$> Decode.decodeStackWithFrameUnpack unpackStackFrameWithIpProvId snapshot
-
-unpackStackFrameWithIpProvId :: Decode.StackFrameLocation -> IO (StackFrame, Maybe Word64)
-unpackStackFrameWithIpProvId stackFrameLoc = do
-  Decode.unpackStackFrameTo stackFrameLoc
-    (\ info infoKey _nextChunk@(StackSnapshot stack#) -> do
-      -- TODO: We don't want to decode the stack frames at all,
-      -- we only need to decode the 'AnnFrame' stack frame.
-      -- framesWithIpe <- decodeStackWithIpProvId nextChunk
-      mIpeId <- lookupIpProvId infoKey
-      pure
-        ( UnderflowFrame
-          { info_tbl = info,
-            nextChunk =
-              GenStgStackClosure
-                { ssc_info = info,
-                  ssc_stack_size = Decode.getStackFields stack#,
-                  ssc_stack = [] -- map fst framesWithIpe
-                }
-          }
-        , mIpeId
-        )
-
-    )
-    (\ frame infoKey -> do
-      mIpeId <- lookupIpProvId infoKey
-      pure (frame, mIpeId))
-
-stackFrameToStackItem :: StackFrame -> Maybe Word64 -> Maybe StackItem
-stackFrameToStackItem frame mIpe =
-  case frame of
-    AnnFrame { annotation = Box someStackAnno } ->
-      case unsafeCoerce someStackAnno of
-        SomeStackAnnotation ann ->
-          case cast ann of
-            Just (CallStackAnnotation cs) ->
-              case getCallStack cs of
-                [] -> Nothing
-                ((name, sourceLoc):_) ->
-                  Just $ SourceLocation $ MkSourceLocation
-                    { line = intToWord32 $ srcLocStartLine sourceLoc
-                    , column = intToWord32 $ srcLocStartCol sourceLoc
-                    , functionName = Text.pack $ name
-                    , fileName = Text.pack $ srcLocFile sourceLoc
-                    }
-
-            Nothing -> case cast ann of
-              Just (StringAnnotation msg) ->
-                Just $ UserMessage msg
-              Nothing ->
-                Nothing
-    _ ->
-      IpeId . MkIpeId <$> mIpe

--- a/ghc-stack-profiler/src/GHC/Stack/Profiler/Sampler.hs
+++ b/ghc-stack-profiler/src/GHC/Stack/Profiler/Sampler.hs
@@ -32,10 +32,10 @@ import GHC.Stack.CloneStack (cloneThreadStack)
 
 import qualified Debug.Trace.Binary.Compat as Compat
 import GHC.Stack.Profiler.Decode
-import GHC.Stack.Profiler.Eventlog
-import GHC.Stack.Profiler.ThreadSample
-import GHC.Stack.Profiler.SymbolTable
-import GHC.Stack.Profiler.Util
+import GHC.Stack.Profiler.Core.Eventlog
+import GHC.Stack.Profiler.Core.ThreadSample
+import GHC.Stack.Profiler.Core.SymbolTable
+import GHC.Stack.Profiler.Core.Util
 
 -- | A 'StackProfilerManager' records all the relevant information
 -- to manage the ghc stack profiler run-time.

--- a/ghc-stack-profiler/src/GHC/Stack/Profiler/Stack/Compat.hs
+++ b/ghc-stack-profiler/src/GHC/Stack/Profiler/Stack/Compat.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE CPP #-}
+module GHC.Stack.Profiler.Stack.Compat (
+  lookupIpeIdForStackFrame,
+) where
+
+import Data.Binary
+import GHC.Internal.InfoProv.Types.Compat
+import GHC.Internal.Stack.Decode.Compat
+
+#if !MIN_VERSION_ghc_internal(9,1500,0)
+import GHC.Stack.Profiler.Util (castPtrToWord64)
+#endif
+
+lookupIpeIdForStackFrame :: StackInfoTable -> IO (Maybe Word64)
+lookupIpeIdForStackFrame itbl = do
+  mId <- lookupIpeId (infoTablePtr itbl)
+#if MIN_VERSION_ghc_internal(9,1500,0)
+  pure mId
+#else
+  -- In GHC <9.14, the key for looking up the InfoProv is the Ptr to the 'StgInfoTable'
+  -- However, to the eventlog, we write the address of the struct.
+  -- So, to check whether there is an InfoProv, we first lookup by the 'StgInfoTable' ptr,
+  -- i.e. not adjusting for 'TABLES_NEXT_TO_CODE', but if there is an entry, we use the
+  -- the struct address, otherwise the decoder will not be able to find the 'InfoProv'.
+  pure $ castPtrToWord64 (infoTableStructPtr itbl) <$ mId
+#endif
+
+

--- a/ghc-stack-profiler/src/GHC/Stack/Profiler/Stack/Decode.hs
+++ b/ghc-stack-profiler/src/GHC/Stack/Profiler/Stack/Decode.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE MagicHash #-}
+module GHC.Stack.Profiler.Stack.Decode (
+  decodeStackWithIpProvId,
+) where
+
+import Unsafe.Coerce (unsafeCoerce)
+import Data.Maybe (catMaybes)
+import qualified Data.Text as Text
+import Data.Typeable (cast)
+
+import GHC.Stack.Annotation.Experimental.Compat
+import GHC.Stack.CloneStack (StackSnapshot(..))
+import GHC.Internal.ClosureTypes.Compat
+import GHC.Internal.Stack.Constants.Compat
+import GHC.Internal.Stack.Decode.Compat as Decode
+import GHC.Internal.Stack.Types
+
+import GHC.Exts.Heap.InfoTable.Types
+
+import GHC.Stack.Profiler.Core.ThreadSample
+import GHC.Stack.Profiler.Core.Eventlog
+import GHC.Stack.Profiler.Core.Util
+import GHC.Stack.Profiler.Stack.Compat (lookupIpeIdForStackFrame)
+
+decodeStackWithIpProvId :: StackSnapshot -> IO [StackItem]
+decodeStackWithIpProvId (StackSnapshot stack#) = do
+  info <- getInfoTableForStack stack#
+  case tipe info of
+    STACK -> do
+      let sfls = stackFrameLocations stack#
+      stack' <- stackFrameLocationItems sfls
+      pure stack'
+    _ -> error $ "Expected STACK closure, got " ++ show info
+  where
+    stackFrameLocations :: StackSnapshot# -> [StackFrameLocation]
+    stackFrameLocations s# =
+      stackHead s#
+        : go (advanceStackFrameLocation (stackHead s#))
+      where
+        go :: Maybe StackFrameLocation -> [StackFrameLocation]
+        go Nothing = []
+        go (Just r) = r : go (advanceStackFrameLocation r)
+
+stackFrameLocationItems :: [StackFrameLocation] -> IO [StackItem]
+stackFrameLocationItems frames =
+  catMaybes <$> traverse stackFrameLocationItem frames
+
+stackFrameLocationItem :: StackFrameLocation -> IO (Maybe StackItem)
+stackFrameLocationItem (StackSnapshot stack#, index) = do
+  stackItbl <- getInfoTableOnStack stack# index
+  case tipe (infoTable stackItbl) of
+    ANN_FRAME ->
+      let Box annotation = getClosureBox stack# (index + offsetStgAnnFrameAnn)
+       in pure $ stackAnnotationToStackItem (unsafeCoerce annotation)
+    _ ->
+      fmap (IpeId . MkIpeId) <$> lookupIpeIdForStackFrame stackItbl
+
+stackAnnotationToStackItem :: SomeStackAnnotation -> Maybe StackItem
+stackAnnotationToStackItem = \ case
+  SomeStackAnnotation ann ->
+    case cast ann of
+      Just (CallStackAnnotation cs) ->
+        case getCallStack cs of
+          [] -> Nothing
+          ((name, sourceLoc):_) ->
+            Just $ SourceLocation $ MkSourceLocation
+              { line = intToWord32 $ srcLocStartLine sourceLoc
+              , column = intToWord32 $ srcLocStartCol sourceLoc
+              , functionName = Text.pack $ name
+              , fileName = Text.pack $ srcLocFile sourceLoc
+              }
+
+      Nothing -> case cast ann of
+        Just (StringAnnotation msg) ->
+          Just $ UserMessage msg
+        Nothing ->
+          Nothing

--- a/ghc-stack-profiler/src/GHC/Stack/Profiler/Util.hs
+++ b/ghc-stack-profiler/src/GHC/Stack/Profiler/Util.hs
@@ -1,0 +1,10 @@
+module GHC.Stack.Profiler.Util (
+  castPtrToWord64,
+) where
+
+import Foreign.Ptr
+import Data.Word
+
+castPtrToWord64 :: Ptr a -> Word64
+castPtrToWord64 ptr = case ptrToWordPtr ptr of
+  WordPtr w -> fromIntegral w -- On platforms that use 32-bit systems, the key is still Word64


### PR DESCRIPTION
Backports changes and the RTS callstack decoder for use with GHC 9.14 and 9.12.

The backports are only included on older versions of GHC. Further, the Compat modules are written in a forward compatible way, such that dropping them should be easy in the future.

Also, since we finally support standard GHC versions, let's add CI!