### PR TITLE
Remove .hsc file from autogen-modules section

### DIFF
--- a/ghc-stack-profiler-core/ghc-stack-profiler-core.cabal
+++ b/ghc-stack-profiler-core/ghc-stack-profiler-core.cabal
@@ -6,7 +6,7 @@ author: Hannes Siebenhandl, Wen Kokke, Matthew Pickering
 maintainer: hannes@well-typed.com
 build-type: Simple
 extra-doc-files: CHANGELOG.md
-tested-with: GHC ==9.14 || ==9.12 || ==9.10
+tested-with: ghc ==9.14 || ==9.12 || ==9.10
 
 common warnings
   ghc-options:
@@ -15,12 +15,12 @@ common warnings
 
 common exts
   default-extensions:
+    DeriveGeneric
+    DerivingStrategies
     DuplicateRecordFields
+    LambdaCase
     NamedFieldPuns
     ViewPatterns
-    LambdaCase
-    DerivingStrategies
-    DeriveGeneric
 
 library
   import:
@@ -45,4 +45,3 @@ library
     src
 
   default-language: GHC2021
-

--- a/ghc-stack-profiler-speedscope/ghc-stack-profiler-speedscope.cabal
+++ b/ghc-stack-profiler-speedscope/ghc-stack-profiler-speedscope.cabal
@@ -6,7 +6,7 @@ author: Hannes Siebenhandl, Wen Kokke, Matthew Pickering
 maintainer: hannes@well-typed.com
 build-type: Simple
 extra-doc-files: CHANGELOG.md
-tested-with: GHC ==9.14 || ==9.12 || ==9.10
+tested-with: ghc ==9.14 || ==9.12 || ==9.10
 
 common warnings
   ghc-options:
@@ -15,15 +15,17 @@ common warnings
 
 common exts
   default-extensions:
+    DeriveGeneric
+    DerivingStrategies
     DuplicateRecordFields
+    LambdaCase
     NamedFieldPuns
     ViewPatterns
-    LambdaCase
-    DerivingStrategies
-    DeriveGeneric
 
 common runopts
-  ghc-options: -threaded -rtsopts
+  ghc-options:
+    -threaded
+    -rtsopts
 
 library
   import:

--- a/ghc-stack-profiler/ghc-stack-profiler.cabal
+++ b/ghc-stack-profiler/ghc-stack-profiler.cabal
@@ -46,9 +46,6 @@ library
     GHC.Stack.Profiler.Stack.Decode
     GHC.Stack.Profiler.Util
 
-  autogen-modules:
-    GHC.Internal.InfoProv.Types.Compat
-
   build-depends:
     base,
     binary,

--- a/ghc-stack-profiler/ghc-stack-profiler.cabal
+++ b/ghc-stack-profiler/ghc-stack-profiler.cabal
@@ -6,7 +6,7 @@ author: Hannes Siebenhandl, Wen Kokke, Matthew Pickering
 maintainer: hannes@well-typed.com
 build-type: Simple
 extra-doc-files: CHANGELOG.md
-tested-with: GHC ==9.14 || ==9.12 || ==9.10
+tested-with: ghc ==9.14 || ==9.12 || ==9.10
 
 common warnings
   ghc-options:
@@ -15,13 +15,13 @@ common warnings
 
 common exts
   default-extensions:
-    DuplicateRecordFields
-    NamedFieldPuns
-    ViewPatterns
-    LambdaCase
-    DerivingStrategies
     DeriveGeneric
+    DerivingStrategies
+    DuplicateRecordFields
+    LambdaCase
+    NamedFieldPuns
     PatternSynonyms
+    ViewPatterns
 
 flag use-ghc-trace-events
   description: Use the package 'ghc-trace-events'
@@ -37,8 +37,8 @@ library
     GHC.Internal.ClosureTypes.Compat
     GHC.Internal.Heap.Closures.Compat
     GHC.Internal.InfoProv.Types.Compat
-    GHC.Internal.Stack.Decode.Compat
     GHC.Internal.Stack.Constants.Compat
+    GHC.Internal.Stack.Decode.Compat
     GHC.Stack.Annotation.Experimental.Compat
     GHC.Stack.Profiler.Decode
     GHC.Stack.Profiler.Sampler
@@ -53,29 +53,30 @@ library
     base,
     binary,
     bytestring,
+    ghc-heap,
     ghc-internal,
     ghc-stack-profiler-core,
     text,
-    ghc-heap,
 
-  if impl(ghc >= 9.14)
-    build-depends: ghc-experimental,
+  if impl(ghc >=9.14)
+    build-depends: ghc-experimental
 
   if flag(use-ghc-trace-events)
     cpp-options:
-        -DUSE_GHC_TRACE_EVENTS
+      -DUSE_GHC_TRACE_EVENTS
+
     build-depends:
-        ghc-trace-events,
+      ghc-trace-events
   else
     build-depends:
-        ghc-prim,
+      ghc-prim
 
-  if impl(ghc < 9.14)
+  if impl(ghc <9.14)
     cmm-sources:
       cbits/Stack.cmm
+
     c-sources:
       cbits/Stack_c.c
-
   hs-source-dirs:
     src
 


### PR DESCRIPTION
Otherwise it is impossible to depend on `ghc-stack-profiler`