### PR TITLE
Support ipedb to store InfoProvs

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,3 +12,8 @@ if impl(ghc >=9.14)
         template-haskell,
         ghc-bignum,
         containers,
+
+source-repository-package
+    type: git
+    location: https://github.com/well-typed/ipedb.git
+    tag: 8e4be73ba989fbe1f04654af6cfed310b2f13d6e

--- a/ghc-stack-profiler-speedscope/ghc-stack-profiler-speedscope.cabal
+++ b/ghc-stack-profiler-speedscope/ghc-stack-profiler-speedscope.cabal
@@ -28,6 +28,7 @@ common exts
     LambdaCase
     NamedFieldPuns
     ViewPatterns
+    NoImportQualifiedPost
 
 common runopts
   ghc-options:
@@ -40,16 +41,20 @@ library
 
   exposed-modules:
     GHC.Stack.Profiler.Speedscope
+    GHC.Stack.Profiler.Speedscope.IpeDb
+    GHC.Stack.Profiler.Speedscope.Options
+    GHC.Stack.Profiler.Speedscope.Types
 
   build-depends:
     aeson >=2.2 && <2.3,
     base >=4.20 && <4.23,
-    bytestring >=0.11   && <0.13,
+    bytestring >=0.11 && <0.13,
     containers >=0.6.8 && <0.9,
     extra ^>=1.8.1,
     ghc-events ^>=0.20,
     ghc-stack-profiler-core ^>=0.1,
     hs-speedscope ^>=0.3,
+    ipedb ^>=0.1.0.0,
     machines ^>=0.7.4,
     optparse-applicative ^>=0.19,
     text >=2 && <2.2,
@@ -79,4 +84,3 @@ source-repository head
   type: git
   location: https://github.com/well-typed/ghc-stack-profiler.git
   subdir: ghc-stack-profiler-speedscope
-

--- a/ghc-stack-profiler-speedscope/src/GHC/Stack/Profiler/Speedscope/IpeDb.hs
+++ b/ghc-stack-profiler-speedscope/src/GHC/Stack/Profiler/Speedscope/IpeDb.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+
+module GHC.Stack.Profiler.Speedscope.IpeDb (toSpeedscopeInfoProv) where
+
+import qualified GHC.Stack.Profiler.Speedscope.Types as Speedscope
+import qualified IpeDb.InfoProv as IpeDb
+
+toSpeedscopeInfoProv :: IpeDb.InfoProv -> Speedscope.InfoProv
+toSpeedscopeInfoProv ipedb_info_prov =
+  Speedscope.InfoProv
+    { Speedscope.infoProvId = Speedscope.InfoProvId ipedb_info_prov.infoId.id
+    , Speedscope.infoProvSrcLoc = ipedb_info_prov.srcLoc
+    , Speedscope.infoProvModule = ipedb_info_prov.moduleName
+    , Speedscope.infoProvLabel = ipedb_info_prov.label
+    , Speedscope.infoTableName = ipedb_info_prov.tableName
+    , Speedscope.infoClosureDesc = fromIntegral ipedb_info_prov.closureDesc
+    , Speedscope.infoTyDesc = ipedb_info_prov.typeDesc
+    }

--- a/ghc-stack-profiler-speedscope/src/GHC/Stack/Profiler/Speedscope/Options.hs
+++ b/ghc-stack-profiler-speedscope/src/GHC/Stack/Profiler/Speedscope/Options.hs
@@ -1,0 +1,63 @@
+module GHC.Stack.Profiler.Speedscope.Options where
+
+import Data.Text (Text)
+import Options.Applicative
+
+data SSOptions = SSOptions
+  { file :: FilePath
+  , isolateStart :: Maybe Text
+  , isolateEnd :: Maybe Text
+  , aggregationMode :: Aggregation
+  , ipeDbConf :: Maybe IpeConf
+  }
+  deriving (Show)
+
+data IpeConf = IpeConf
+  { file :: FilePath
+  , index :: Bool
+  }
+  deriving (Show)
+
+data Aggregation
+  = PerThread
+  | PerCapability
+  | NoAggregation
+  deriving (Show, Eq, Ord)
+
+options :: ParserInfo SSOptions
+options =
+  info
+    (optsParser <**> helper)
+    ( fullDesc
+        <> progDesc "Generate a speedscope.app json file from an eventlog"
+        <> header "hs-speedscope"
+    )
+
+optsParser :: Parser SSOptions
+optsParser =
+  SSOptions
+    <$> argument str (metavar "FILE.eventlog")
+    <*> optional
+      ( strOption
+          ( short 's'
+              <> long "start"
+              <> metavar "STRING"
+              <> help "No samples before the first eventlog message with this prefix will be included in the output"
+          )
+      )
+    <*> optional
+      ( strOption
+          (short 'e' <> long "end" <> metavar "STRING" <> help "No samples after the first eventlog message with this prefix will be included in the output")
+      )
+    <*> ( flag' PerThread (long "per-thread" <> help "Group the profile per thread (default)")
+            <|> flag' PerCapability (long "per-capability" <> help "Group the profile per capability")
+            <|> flag' NoAggregation (long "no-aggregation" <> help "Perform no grouping, single view")
+            <|> pure PerThread
+        )
+    <*> optional ipeConfParser
+
+ipeConfParser :: Parser IpeConf
+ipeConfParser =
+  IpeConf
+    <$> strOption (short 'f' <> long "ipedb" <> metavar "FILE" <> help "'ipedb' database location")
+    <*> flag False True (long "index" <> help "Create an index on-the-fly at the database location instead of in-memory database. Will overwrite any existing database.")

--- a/ghc-stack-profiler-speedscope/src/GHC/Stack/Profiler/Speedscope/Types.hs
+++ b/ghc-stack-profiler-speedscope/src/GHC/Stack/Profiler/Speedscope/Types.hs
@@ -1,0 +1,40 @@
+module GHC.Stack.Profiler.Speedscope.Types where
+
+import Data.Text (Text)
+import Data.Word (Word64)
+import GHC.Stack.Profiler.Core.Eventlog (CapabilityId)
+import GHC.Stack.Profiler.Core.SourceLocation (SourceLocation)
+
+data InfoProv = InfoProv
+  { infoProvId :: !InfoProvId
+  , infoProvSrcLoc :: !Text
+  , infoProvModule :: !Text
+  , infoProvLabel :: !Text
+  , infoTableName :: !Text
+  , infoClosureDesc :: !Int
+  , infoTyDesc :: !Text
+  }
+  deriving (Eq, Ord, Show)
+
+data Sample = Sample
+  { sampleThreadId :: !Word64
+  -- ^ thread id
+  , sampleCapabilityId :: !CapabilityId
+  -- ^ Capability id
+  , sampleCostCentreStack :: [CostCentreId]
+  -- ^ stack ids
+  }
+  deriving (Eq, Ord, Show)
+
+newtype CostCentreId = CostCentreId Word64
+  deriving (Eq, Ord, Show)
+  deriving newtype (Num)
+
+newtype InfoProvId = InfoProvId Word64
+  deriving (Eq, Ord, Show)
+
+data UserCostCentre
+  = CostCentreMessage !Text
+  | CostCentreSrcLoc !SourceLocation
+  | CostCentreIpe !InfoProv
+  deriving (Eq, Ord, Show)


### PR DESCRIPTION
Allows to index the InfoProvs that occur in the eventlog before processing `ghc-stack-profiler` events.
This is slower than the in-memory processing, but uses less memory.

We support both, pre-indexed databases and to ad-hoc generate an index for faster processing later.