### PR TITLE
Update base dependency version range

### DIFF
--- a/ghc-stack-profiler-core/ghc-stack-profiler-core.cabal
+++ b/ghc-stack-profiler-core/ghc-stack-profiler-core.cabal
@@ -44,7 +44,7 @@ library
     GHC.Stack.Profiler.Core.Util
 
   build-depends:
-    base >=4.20 && <4.23,
+    base >=4.18 && <4.23,
     binary >=0.8.9.3 && <0.11,
     bytestring >=0.11 && <0.13,
     containers >=0.6.8 && <0.9,


### PR DESCRIPTION
Allow to build `ghc-stack-profiler-core` with GHC 9.6 and 9.8.