### PR TITLE
Add support for eventlog-socket lifecycle hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ cabal.project.local
 *.eventlog.html
 *.hp
 sdist/
+
+# editor specific
+.vscode/
+.zed/
+
+# direnv
+.envrc

--- a/cabal.project
+++ b/cabal.project
@@ -8,7 +8,7 @@ optional-packages:
   examples/simple-scope/
 
 if !os(windows)
-  optional-package:
+  optional-packages:
     examples/eventlog-socket-example/
 
   -- In this project, we always build with '+control' on non-windows

--- a/cabal.project
+++ b/cabal.project
@@ -24,3 +24,9 @@ if impl(ghc >=9.14)
     template-haskell,
     ghc-bignum,
     containers,
+
+source-repository-package
+    type: git
+    location: https://github.com/well-typed/eventlog-socket
+    tag: 539f89c9a1371112e2d56524f73f223d1ffa0040
+    subdir: eventlog-socket

--- a/examples/eventlog-socket-example/app/Main.hs
+++ b/examples/eventlog-socket-example/app/Main.hs
@@ -9,7 +9,7 @@ import System.Directory
 import System.IO.Temp
 
 main :: IO ()
-main = setupRootStackProfiler False $ \ manager -> withStackProfiler manager (SampleIntervalMs 10) $ do
+main = withRootStackProfiler False $ \ manager -> withStackProfiler manager (SampleIntervalMs 10) $ do
   mfp <- lookupEnv "EVENTLOG_SOCKET_EXAMPLE_SOCKET"
   fp <- maybe
     (do

--- a/examples/simple-scope/app/Main.hs
+++ b/examples/simple-scope/app/Main.hs
@@ -5,7 +5,7 @@ import GHC.Stack.Annotation
 import GHC.Stack.Profiler
 
 main :: IO ()
-main = setupRootStackProfiler True $ \ manager -> do
+main = withRootStackProfiler True $ \ manager -> do
   withStackProfilerForMyThread manager (SampleIntervalMs 10) $ print $ annotateStackString "fib 41" $ fib 41
   print $ annotateStackString "fib 42" $ fib 42
   withStackProfilerForMyThread manager (SampleIntervalMs 10) $ print $ annotateStackString "fib 43" $ fib 43

--- a/examples/simple/app/Main.hs
+++ b/examples/simple/app/Main.hs
@@ -5,7 +5,7 @@ import GHC.Stack.Annotation
 import GHC.Stack.Profiler
 
 main :: IO ()
-main = setupRootStackProfiler True $ \ manager -> withStackProfiler manager (SampleIntervalMs 10) $ do
+main = withRootStackProfiler True $ \ manager -> withStackProfiler manager (SampleIntervalMs 10) $ do
   print $ annotateStackString "fib 41" $ fib 41
   print $ annotateStackString "fib 42" $ fib 42
   print $ annotateStackString "fib 43" $ fib 43

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,0 +1,51 @@
+# Number of spaces per indentation step
+indentation: 2
+
+# Max line length for automatic line breaking
+column-limit: none
+
+# Styling of arrows in type signatures (choices: trailing, leading, or leading-args)
+function-arrows: trailing
+
+# How to place commas in multi-line lists, records, etc. (choices: leading or trailing)
+comma-style: leading
+
+# Styling of import/export lists (choices: leading, trailing, or diff-friendly)
+import-export-style: diff-friendly
+
+# Whether to full-indent or half-indent 'where' bindings past the preceding body
+indent-wheres: false
+
+# Whether to leave a space before an opening record brace
+record-brace-space: false
+
+# Number of spaces between top-level declarations
+newlines-between-decls: 1
+
+# How to print Haddock comments (choices: single-line, multi-line, or multi-line-compact)
+haddock-style: single-line
+
+# How to print module docstring
+haddock-style-module: null
+
+# Styling of let blocks (choices: auto, inline, newline, or mixed)
+let-style: newline
+
+# How to align the 'in' keyword with respect to the 'let' keyword (choices: left-align, right-align, or no-space)
+in-style: left-align
+
+# Whether to put parentheses around a single constraint (choices: auto, always, or never)
+single-constraint-parens: always
+
+# Output Unicode syntax (choices: detect, always, or never)
+unicode: never
+
+# Give the programmer more choice on where to insert blank lines
+respectful: true
+
+# Fixity information for operators
+fixities: []
+
+# Module reexports Fourmolu should know about
+reexports: []
+

--- a/ghc-stack-profiler-core/src/GHC/Stack/Profiler/Core/Eventlog.hs
+++ b/ghc-stack-profiler-core/src/GHC/Stack/Profiler/Core/Eventlog.hs
@@ -1,16 +1,16 @@
 module GHC.Stack.Profiler.Core.Eventlog (
   -- * Eventlgog Message types
-  BinaryEventlogMessage(..),
-  BinaryCallStackMessage(..),
-  BinaryStringMessage(..),
-  BinarySourceLocationMessage(..),
-  BinaryStackItem(..),
-  CapabilityId(..),
-  StringId(..),
+  BinaryEventlogMessage (..),
+  BinaryCallStackMessage (..),
+  BinaryStringMessage (..),
+  BinarySourceLocationMessage (..),
+  BinaryStackItem (..),
+  CapabilityId (..),
+  StringId (..),
   incrementStringLocationId,
-  SourceLocationId(..),
+  SourceLocationId (..),
   incrementSourceLocationId,
-  IpeId(..),
+  IpeId (..),
 
   -- * Eventlog constants
   callStackFinalMessageTag,
@@ -60,7 +60,6 @@ import GHC.Stack.Profiler.Core.Util
 --   := <length: Int16> <Char>+
 --    # check that length < 2^16-8
 -- @
---
 data BinaryEventlogMessage
   = CallStackFinal !BinaryCallStackMessage
   | CallStackChunk !BinaryCallStackMessage
@@ -97,10 +96,10 @@ data BinaryStackItem
   deriving (Eq, Ord, Show, Generic)
 
 -- | Simple newtype for the ID of a capability.
-newtype CapabilityId =
-  MkCapabilityId
-    { getCapabilityId :: Word64
-    }
+newtype CapabilityId
+  = MkCapabilityId
+  { getCapabilityId :: Word64
+  }
   deriving (Show, Eq, Ord, Generic)
 
 newtype StringId = MkStringId
@@ -154,24 +153,26 @@ eventlogBufferSize = (2 :: Word64) ^ (16 :: Word64)
 
 -- | Size limit of strings that can occur in the eventlog.
 stringLengthLimit :: Word16
-stringLengthLimit = word64ToWord16 $
+stringLengthLimit =
+  word64ToWord16 $
     eventlogBufferSize
       - 2 {- 0xFFCC -}
       - 8 {- Word64 of 'StringId' -}
       - 2 {- Word16 for the length of the string to serialise -}
 
 callStackItemLimit :: Word16
-callStackItemLimit = word64ToWord16
+callStackItemLimit =
+  word64ToWord16
     ( eventlogBufferSize
-      - 2 {- 0xFFCA or 0xFFCB -}
-      - 4 {- Word32 of 'CapabilityId' -}
-      - 4 {- Word32 of 'ThreadId' -}
-      - 2 {- Word16 for the length of stack entry -}
+        - 2 {- 0xFFCA or 0xFFCB -}
+        - 4 {- Word32 of 'CapabilityId' -}
+        - 4 {- Word32 of 'ThreadId' -}
+        - 2 {- Word16 for the length of stack entry -}
     )
     `div` 9 {- Each 'BinaryStackItem' has at most 9 bytes -}
 
 instance Binary BinaryEventlogMessage where
-  put = \ case
+  put = \case
     CallStackFinal msg ->
       putWithTag callStackFinalMessageTag msg
     CallStackChunk msg ->
@@ -180,8 +181,8 @@ instance Binary BinaryEventlogMessage where
       putWithTag callStackStringMessageTag msg
     SourceLocationDef msg ->
       putWithTag callStackSourceLocationMessageTag msg
-    where
-      putWithTag t msg = putWord16 t >> put msg
+   where
+    putWithTag t msg = putWord16 t >> put msg
 
   get = do
     tag <- getWord16
@@ -196,16 +197,20 @@ instance Binary BinaryEventlogMessage where
         | tag == callStackSourceLocationMessageTag ->
             SourceLocationDef <$> get
         | otherwise ->
-            fail $ "BinaryEventlogMessage.get: Unknown tag expected one of " ++ tags
-              ++ " but got " ++ showAsHex tag
-    where
-      tags = List.intercalate ", " $ map showAsHex callStackMessageTags
+            fail $
+              "BinaryEventlogMessage.get: Unknown tag expected one of "
+                ++ tags
+                ++ " but got "
+                ++ showAsHex tag
+   where
+    tags = List.intercalate ", " $ map showAsHex callStackMessageTags
 
 instance Binary BinaryCallStackMessage where
   put msg = do
     putWord32 $ word64ToWord32 $ getCapabilityId $ binaryCallCapabilityId msg
     putWord32 $ word64ToWord32 $ binaryCallThreadId msg
-    let items = binaryCallStack msg
+    let
+      items = binaryCallStack msg
     putWord16 $ intToWord16 $ length items
     mapM_ put items
 
@@ -214,14 +219,15 @@ instance Binary BinaryCallStackMessage where
     tid <- getWord32
     len <- getWord16
     items <- replicateM (word16ToInt len) get
-    pure MkBinaryCallStackMessage
-      { binaryCallThreadId = word32ToWord64 tid
-      , binaryCallCapabilityId = MkCapabilityId $ word32ToWord64 capId
-      , binaryCallStack = items
-      }
+    pure
+      MkBinaryCallStackMessage
+        { binaryCallThreadId = word32ToWord64 tid
+        , binaryCallCapabilityId = MkCapabilityId $ word32ToWord64 capId
+        , binaryCallStack = items
+        }
 
 instance Binary BinaryStackItem where
-  put = \ case
+  put = \case
     BinaryIpe ipeId -> do
       putWord8 1
       put ipeId
@@ -233,7 +239,7 @@ instance Binary BinaryStackItem where
       put lid
 
   get = do
-    getWord8 >>= \ case
+    getWord8 >>= \case
       1 -> BinaryIpe <$> get
       2 -> BinaryString <$> get
       3 -> BinarySourceLocation <$> get

--- a/ghc-stack-profiler-core/src/GHC/Stack/Profiler/Core/SourceLocation.hs
+++ b/ghc-stack-profiler-core/src/GHC/Stack/Profiler/Core/SourceLocation.hs
@@ -1,15 +1,14 @@
 module GHC.Stack.Profiler.Core.SourceLocation where
 
-import Data.Word (Word32)
 import Data.Text (Text)
+import Data.Word (Word32)
 import GHC.Generics (Generic)
 
 -- | A Haskell source location.
-data SourceLocation =
-  MkSourceLocation
-    { line :: !Word32
-    , column :: !Word32
-    , functionName :: !Text
-    , fileName :: !Text
-    }
+data SourceLocation = MkSourceLocation
+  { line :: !Word32
+  , column :: !Word32
+  , functionName :: !Text
+  , fileName :: !Text
+  }
   deriving (Eq, Ord, Show, Generic)

--- a/ghc-stack-profiler-core/src/GHC/Stack/Profiler/Core/SymbolTable.hs
+++ b/ghc-stack-profiler-core/src/GHC/Stack/Profiler/Core/SymbolTable.hs
@@ -1,27 +1,34 @@
 module GHC.Stack.Profiler.Core.SymbolTable (
   -- * Abstract interfaces for transforming 'CallStackMessage's and
+
   -- 'BinaryEventlogMessage' into each other.
-  SymbolTableWriter(..),
-  SymbolTableReader(..),
+  SymbolTableWriter (..),
+  SymbolTableReader (..),
+
   -- * A 'Map' implementation for the 'SymbolTableWriter' interface.
   MapTable,
   emptyMapSymbolTableWriter,
+  getKnownStrings,
+  getKnownSourceLocations,
+
   -- * An 'IntMap' implementation for the 'SymbolTableReader' interface.
   IntMapTable,
-  MissingKeyError(..),
+  MissingKeyError (..),
   mkIntMapSymbolTableReader,
   emptyIntMapTable,
   insertSourceLocationMessage,
   insertTextMessage,
 ) where
 
-import Data.Text (Text)
+import Control.Exception
 import Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as IntMap
+import qualified Data.List as List
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Tuple as Tuple
 import GHC.Generics (Generic)
-
 import GHC.Stack.Profiler.Core.Eventlog
 import GHC.Stack.Profiler.Core.SourceLocation
 import GHC.Stack.Profiler.Core.Util
@@ -40,21 +47,20 @@ import GHC.Stack.Profiler.Core.Util
 -- As these symbols are discovered while encoding the callstack, the 'SymbolTableWriter'
 -- needs to be extended, which is why we thread the 'tbl' parameter through the
 -- lookup or insertion operations.
-data SymbolTableWriter tbl =
-  MkSymbolTableWriter
-    { writerTable :: tbl
-    -- ^ Symbol table for symbols we replace with unique identifiers.
-    , lookupOrInsertText :: tbl -> Text -> (StringId, Bool, tbl)
-    -- ^ Lookup up the given 'Text' in the 'tbl' Symbol table.
-    -- If the 'Text' can't be found, we insert it into the table and generate a
-    -- new 'StringId.
-    -- Returns 'True', if the given 'Text' was inserted and 'False' otherwise.
-    , lookupOrInsertSourceLocation :: tbl -> SourceLocation -> (SourceLocationId, Bool, tbl)
-    -- ^ Lookup up the given 'SourceLocation' in the 'tbl' Symbol table.
-    -- If the 'SourceLocation' can't be found, we insert it into the table and generate a
-    -- new 'SourceLocationId.
-    -- Returns 'True', if the given 'Text' was inserted and 'False' otherwise.
-    }
+data SymbolTableWriter tbl = MkSymbolTableWriter
+  { writerTable :: !tbl
+  -- ^ Symbol table for symbols we replace with unique identifiers.
+  , lookupOrInsertText :: tbl -> Text -> (StringId, Bool, tbl)
+  -- ^ Lookup up the given 'Text' in the 'tbl' Symbol table.
+  -- If the 'Text' can't be found, we insert it into the table and generate a
+  -- new 'StringId.
+  -- Returns 'True', if the given 'Text' was inserted and 'False' otherwise.
+  , lookupOrInsertSourceLocation :: tbl -> SourceLocation -> (SourceLocationId, Bool, tbl)
+  -- ^ Lookup up the given 'SourceLocation' in the 'tbl' Symbol table.
+  -- If the 'SourceLocation' can't be found, we insert it into the table and generate a
+  -- new 'SourceLocationId.
+  -- Returns 'True', if the given 'Text' was inserted and 'False' otherwise.
+  }
   deriving (Generic)
 
 -- | Implementation agnostic symbol table reader helping consumers to decode
@@ -62,15 +68,14 @@ data SymbolTableWriter tbl =
 --
 -- As during deserialisation, we do not discover new Messages, the abstract 'SymbolTableReader'
 -- doesn't need to thread the implementation through the lookup operations.
-data SymbolTableReader =
-  MkSymbolTableReader
-    { lookupStringId :: StringId -> Maybe Text
-    -- ^ Lookup the 'StringId' in the symbol table.
-    -- This operation throws an exception if the 'StringId' is unknown.
-    , lookupSourceLocationId :: SourceLocationId -> Maybe SourceLocation
-    -- ^ Lookup the 'SourceLocationId' in the symbol table.
-    -- This operation throws an exception if the 'SourceLocationId' is unknown.
-    }
+data SymbolTableReader = MkSymbolTableReader
+  { lookupStringId :: StringId -> Maybe Text
+  -- ^ Lookup the 'StringId' in the symbol table.
+  -- This operation throws an exception if the 'StringId' is unknown.
+  , lookupSourceLocationId :: SourceLocationId -> Maybe SourceLocation
+  -- ^ Lookup the 'SourceLocationId' in the symbol table.
+  -- This operation throws an exception if the 'SourceLocationId' is unknown.
+  }
   deriving (Generic)
 
 -- ----------------------------------------------------------------------------
@@ -82,58 +87,58 @@ data MapTable = MkMapTable
   , srcLocTable :: !(Map SourceLocation SourceLocationId)
   , stringUniqueSupply :: {-# UNPACK #-} !StringId
   , srcLocUniqueSupply :: {-# UNPACK #-} !SourceLocationId
-  } deriving (Show, Eq, Ord, Generic)
-
-{-# INLINABLE emptyMapSymbolTableWriter #-}
-emptyMapSymbolTableWriter :: SymbolTableWriter MapTable
-emptyMapSymbolTableWriter = MkSymbolTableWriter
-  { writerTable =
-      MkMapTable
-        { stringTable = Map.empty
-        , srcLocTable = Map.empty
-        , stringUniqueSupply = MkStringId 0
-        , srcLocUniqueSupply = MkSourceLocationId 0
-        }
-  , lookupOrInsertText = alterStringMap
-  , lookupOrInsertSourceLocation = alterSrcLocTable
   }
+  deriving (Show, Eq, Ord, Generic)
 
-  where
-    nextSrcLocUnique tbl =
-      ( srcLocUniqueSupply tbl
-      , tbl
+{-# INLINEABLE emptyMapSymbolTableWriter #-}
+emptyMapSymbolTableWriter :: SymbolTableWriter MapTable
+emptyMapSymbolTableWriter =
+  MkSymbolTableWriter
+    { writerTable =
+        MkMapTable
+          { stringTable = Map.empty
+          , srcLocTable = Map.empty
+          , stringUniqueSupply = MkStringId 0
+          , srcLocUniqueSupply = MkSourceLocationId 0
+          }
+    , lookupOrInsertText = alterStringMap
+    , lookupOrInsertSourceLocation = alterSrcLocTable
+    }
+ where
+  nextSrcLocUnique tbl =
+    ( srcLocUniqueSupply tbl
+    , tbl
         { srcLocUniqueSupply =
             incrementSourceLocationId $ srcLocUniqueSupply tbl
         }
-      )
+    )
 
-    nextStringUnique tbl =
-      ( stringUniqueSupply tbl
-      , tbl
+  nextStringUnique tbl =
+    ( stringUniqueSupply tbl
+    , tbl
         { stringUniqueSupply =
             incrementStringLocationId $ stringUniqueSupply tbl
         }
-      )
+    )
 
-    updateEntry tbl0 nextKey Nothing =
-      let
-        (sid, tbl) = nextKey tbl0
-      in
-        ((sid, True, tbl), Just sid)
+  updateEntry tbl0 nextKey Nothing =
+    let
+      (sid, tbl) = nextKey tbl0
+    in
+      ((sid, True, tbl), Just sid)
+  updateEntry tbl _ (Just val) =
+    ((val, False, tbl), Just val)
 
-    updateEntry tbl _ (Just val) =
-      ((val, False, tbl), Just val)
+  swapAround set ((sid, new, tbl), hm) =
+    (sid, new, set tbl hm)
 
-    swapAround set ((sid, new, tbl), hm) =
-      (sid, new, set tbl hm)
+  alterStringMap = \tbl str ->
+    swapAround setStringTable $
+      Map.alterF (updateEntry tbl nextStringUnique) str (stringTable tbl)
 
-    alterStringMap = \ tbl str ->
-      swapAround setStringTable $
-        Map.alterF (updateEntry tbl nextStringUnique) str (stringTable tbl)
-
-    alterSrcLocTable = \ tbl srcLoc ->
-      swapAround setSourceLocationTable $
-        Map.alterF (updateEntry tbl nextSrcLocUnique) srcLoc (srcLocTable tbl)
+  alterSrcLocTable = \tbl srcLoc ->
+    swapAround setSourceLocationTable $
+      Map.alterF (updateEntry tbl nextSrcLocUnique) srcLoc (srcLocTable tbl)
 
 setSourceLocationTable :: MapTable -> Map SourceLocation SourceLocationId -> MapTable
 setSourceLocationTable tbl hm =
@@ -147,24 +152,47 @@ setStringTable tbl hm =
     { stringTable = hm
     }
 
+getKnownStrings :: MapTable -> [(StringId, Text)]
+{-# INLINEABLE getKnownStrings #-}
+getKnownStrings table =
+  List.map Tuple.swap $ Map.assocs (stringTable table)
+
+getKnownSourceLocations :: MapTable -> [(SourceLocationId, SourceLocation)]
+{-# INLINEABLE getKnownSourceLocations #-}
+getKnownSourceLocations table =
+  List.map Tuple.swap $ Map.assocs (srcLocTable table)
+
 -- ----------------------------------------------------------------------------
 -- Implementation backend for 'SymbolTableReader'
 -- ----------------------------------------------------------------------------
 
 data MissingKeyError
-  = KeyStringIdNotFound SourceLocationId StringId
-  -- ^ We failed to find the 'StringId' to fully decode the 'SourceLocationId'.
+  = -- | We failed to find the 'StringId' to fully decode the 'SourceLocationId'.
+    KeyStringIdNotFound SourceLocationId StringId
+  deriving (Show)
+
+instance Exception MissingKeyError where
+  displayException = \case
+    KeyStringIdNotFound srcLocId stringId ->
+      "While decoding the Source Location ("
+        ++ show (getSourceLocationId srcLocId)
+        ++ "), "
+        ++ "the String ("
+        ++ show (getStringId stringId)
+        ++ ") couldn't be found"
 
 data IntMapTable = MkIntMapTable
   { stringLookupTable :: !(IntMap Text)
   , srcLocLookupTable :: !(IntMap SourceLocation)
-  } deriving (Eq, Ord, Show, Generic)
+  }
+  deriving (Eq, Ord, Show, Generic)
 
 emptyIntMapTable :: IntMapTable
-emptyIntMapTable = MkIntMapTable
-  { stringLookupTable = IntMap.empty
-  , srcLocLookupTable = IntMap.empty
-  }
+emptyIntMapTable =
+  MkIntMapTable
+    { stringLookupTable = IntMap.empty
+    , srcLocLookupTable = IntMap.empty
+    }
 
 mkIntMapSymbolTableReader :: IntMapTable -> SymbolTableReader
 mkIntMapSymbolTableReader tbl =
@@ -173,7 +201,7 @@ mkIntMapSymbolTableReader tbl =
     , lookupSourceLocationId = flip lookupSourceLocationMessage tbl
     }
 
-{-# INLINABLE insertTextMessage #-}
+{-# INLINEABLE insertTextMessage #-}
 insertTextMessage :: BinaryStringMessage -> IntMapTable -> IntMapTable
 insertTextMessage msg tbl =
   tbl
@@ -184,7 +212,7 @@ insertTextMessage msg tbl =
           (stringLookupTable tbl)
     }
 
-{-# INLINABLE insertSourceLocationMessage #-}
+{-# INLINEABLE insertSourceLocationMessage #-}
 insertSourceLocationMessage :: BinarySourceLocationMessage -> IntMapTable -> Either MissingKeyError IntMapTable
 insertSourceLocationMessage msg tbl = do
   let
@@ -197,25 +225,27 @@ insertSourceLocationMessage msg tbl = do
   fileName <-
     maybe (Left $ KeyStringIdNotFound srcLocId fileId) Right $ lookupTextMessage fileId tbl
 
-  pure tbl
-    { srcLocLookupTable =
-        IntMap.insert
-          (idToInt srcLocId)
-          (mkSourceLocation funcName fileName)
-          (srcLocLookupTable tbl)
-    }
-  where
-    mkSourceLocation funcName fileName = MkSourceLocation
+  pure
+    tbl
+      { srcLocLookupTable =
+          IntMap.insert
+            (idToInt srcLocId)
+            (mkSourceLocation funcName fileName)
+            (srcLocLookupTable tbl)
+      }
+ where
+  mkSourceLocation funcName fileName =
+    MkSourceLocation
       { line = binarySourceLocationRow msg
       , column = binarySourceLocationColumn msg
       , functionName = funcName
       , fileName = fileName
       }
 
-{-# INLINABLE lookupTextMessage #-}
+{-# INLINEABLE lookupTextMessage #-}
 lookupTextMessage :: StringId -> IntMapTable -> Maybe Text
 lookupTextMessage sid tbl = IntMap.lookup (idToInt sid) (stringLookupTable tbl)
 
-{-# INLINABLE lookupSourceLocationMessage #-}
-lookupSourceLocationMessage :: SourceLocationId -> IntMapTable -> Maybe  SourceLocation
+{-# INLINEABLE lookupSourceLocationMessage #-}
+lookupSourceLocationMessage :: SourceLocationId -> IntMapTable -> Maybe SourceLocation
 lookupSourceLocationMessage sid tbl = IntMap.lookup (idToInt sid) (srcLocLookupTable tbl)

--- a/ghc-stack-profiler-core/src/GHC/Stack/Profiler/Core/ThreadSample.hs
+++ b/ghc-stack-profiler-core/src/GHC/Stack/Profiler/Core/ThreadSample.hs
@@ -1,41 +1,52 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module GHC.Stack.Profiler.Core.ThreadSample (
-  ThreadSample(..),
+  -- * High-level API
+  ThreadSample (..),
   deserializeEventlogMessage,
 
-  CallStackMessage(..),
-  StackItem(..),
-  SourceLocation(..),
+  -- * Serialisable 'ThreadSample'
+  CallStackMessage (..),
+  StackItem (..),
+  SourceLocation (..),
 
-  SymbolTableWriter(..),
-  SymbolTableReader(..),
+  -- * Serialisation of 'CallStackMessage'
+  SymbolTableWriter (..),
+  SymbolTableReader (..),
   dehydrateCallStackMessage,
-  BinaryCallStackDecodeError(..),
+  BinaryCallStackDecodeError (..),
   hydrateEventlogCallStackMessage,
   catCallStackMessage,
   chunkCallStackMessage,
+
+  -- * Message dehydration helpers
+  EncodingState,
+  runWithEncodingState,
+  newEncodingState,
+  lookupSourceLocationMessage,
+  lookupTextMessage,
 ) where
 
 import Control.Concurrent
+import Control.Exception (Exception (..))
 import Control.Monad (when)
 import Control.Monad.Trans.State.Strict (State, runState)
 import qualified Control.Monad.Trans.State.Strict as State
 import Data.Binary
 import Data.Binary.Get
 import qualified Data.ByteString.Lazy as LBS
-import Data.List.NonEmpty (NonEmpty(..))
+import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Text (Text)
 import qualified Data.Text as Text
 import GHC.Generics
 
+import Data.Either (partitionEithers)
 import GHC.Stack.CloneStack (StackSnapshot)
 import GHC.Stack.Profiler.Core.Eventlog
-import GHC.Stack.Profiler.Core.Util
 import GHC.Stack.Profiler.Core.SourceLocation
 import GHC.Stack.Profiler.Core.SymbolTable
-import Data.Either (partitionEithers)
+import GHC.Stack.Profiler.Core.Util (chunksOf, word16ToInt)
 
 -- ----------------------------------------------------------------------------
 -- Thread Sample
@@ -48,12 +59,11 @@ import Data.Either (partitionEithers)
 -- The 'StackSnapshot' is a boxed value and needs to be garbage collected.
 -- Note, as long as 'StackSnapshot' is alive, you keep the full callstack
 -- alive, which might be quite expensive.
-data ThreadSample =
-  ThreadSample
-    { threadSampleId :: !ThreadId
-    , threadSampleCapability :: !CapabilityId
-    , threadSampleStackSnapshot :: !StackSnapshot
-    }
+data ThreadSample = ThreadSample
+  { threadSampleId :: !ThreadId
+  , threadSampleCapability :: !CapabilityId
+  , threadSampleStackSnapshot :: !StackSnapshot
+  }
   deriving (Generic)
 
 deserializeEventlogMessage :: LBS.ByteString -> Either String BinaryEventlogMessage
@@ -66,13 +76,11 @@ deserializeEventlogMessage msg = case runGetOrFail get msg of
 -- ----------------------------------------------------------------------------
 
 -- | A decoded rts callstack that can be serialised to the EventLog.
---
-data CallStackMessage =
-  MkCallStackMessage
-    { callThreadId :: !Word64
-    , callCapabilityId :: !CapabilityId
-    , callStack :: [StackItem]
-    }
+data CallStackMessage = MkCallStackMessage
+  { callThreadId :: !Word64
+  , callCapabilityId :: !CapabilityId
+  , callStack :: [StackItem]
+  }
   deriving (Eq, Ord, Show, Generic)
 
 data StackItem
@@ -100,15 +108,17 @@ data StackItem
 --    'CallStackFinal' messages. There might not be any such messages.
 -- * Then 'CallStackChunk' follow if there are any.
 -- * The last message is always a 'CallStackFinal' message and it occurs exactly once in @r@.
---
-dehydrateCallStackMessage :: forall table.
+dehydrateCallStackMessage ::
+  forall table.
   SymbolTableWriter table ->
   CallStackMessage ->
   ([BinaryEventlogMessage], SymbolTableWriter table)
 dehydrateCallStackMessage msgTbl0 msg =
   let
     (stackItems, finalState) =
-      runState (mapM go (callStack msg)) initEncodingState
+      runWithEncodingState
+        (newEncodingState msgTbl0)
+        (mapM go (callStack msg))
 
     stringDefs =
       map StringDef $ stringMessages finalState
@@ -117,35 +127,37 @@ dehydrateCallStackMessage msgTbl0 msg =
       map SourceLocationDef $ sourceLocMessages finalState
 
     stackMsgChunks =
-      chunkCallStackMessage callStackItemLimit $ MkBinaryCallStackMessage
-        { binaryCallThreadId = callThreadId msg
-        , binaryCallCapabilityId = callCapabilityId msg
-        , binaryCallStack = stackItems
-        }
+      chunkCallStackMessage callStackItemLimit $
+        MkBinaryCallStackMessage
+          { binaryCallThreadId = callThreadId msg
+          , binaryCallCapabilityId = callCapabilityId msg
+          , binaryCallStack = stackItems
+          }
   in
     ( stringDefs ++ sourceLocDefs ++ stackMsgChunks
     , symbolTableWriter finalState
     )
-
-  where
-    initEncodingState = MkEncodingState
-      { symbolTableWriter = msgTbl0
-      , stringMessages = []
-      , sourceLocMessages = []
-      }
-
-    go :: StackItem -> State (EncodingState tbl) BinaryStackItem
-    go = \ case
-      IpeId ipeId ->
-        pure $ BinaryIpe ipeId
-      UserMessage s ->
-        BinaryString <$> lookupTextMessage (Text.pack s)
-      SourceLocation srcLoc ->
-        BinarySourceLocation <$> lookupSourceLocationMessage srcLoc
+ where
+  go :: StackItem -> State (EncodingState tbl) BinaryStackItem
+  go = \case
+    IpeId ipeId ->
+      pure $ BinaryIpe ipeId
+    UserMessage s ->
+      BinaryString <$> lookupTextMessage (Text.pack s)
+    SourceLocation srcLoc ->
+      BinarySourceLocation <$> lookupSourceLocationMessage srcLoc
 
 data BinaryCallStackDecodeError
   = StringIdNotFound StringId
   | SourceLocationIdNotFound SourceLocationId
+  deriving (Show)
+
+instance Exception BinaryCallStackDecodeError where
+  displayException = \case
+    StringIdNotFound sid ->
+      "Failed to decode a BinaryCallStackMessage. Failed to find a String with the key: " ++ show (getStringId sid)
+    SourceLocationIdNotFound sid ->
+      "Failed to decode a BinaryCallStackMessage. Failed to find a SourceLocation with the key: " ++ show (getSourceLocationId sid)
 
 -- | Generic implementation to turn 'BinaryCallStackMessage' into the much richer
 -- 'CallStackMessage'.
@@ -153,10 +165,9 @@ hydrateEventlogCallStackMessage :: SymbolTableReader -> BinaryCallStackMessage -
 hydrateEventlogCallStackMessage decodeTable msg =
   let
     decodeItem :: BinaryStackItem -> Either BinaryCallStackDecodeError StackItem
-    decodeItem = \ case
+    decodeItem = \case
       BinaryIpe ipeId ->
         Right $ IpeId ipeId
-
       BinaryString stringId ->
         maybe
           (Left $ StringIdNotFound stringId)
@@ -170,13 +181,12 @@ hydrateEventlogCallStackMessage decodeTable msg =
 
     itemsOrErros = map decodeItem (binaryCallStack msg)
     (errors, items) = partitionEithers itemsOrErros
-
   in
     ( MkCallStackMessage
-      { callCapabilityId = binaryCallCapabilityId msg
-      , callThreadId = binaryCallThreadId msg
-      , callStack = items
-      }
+        { callCapabilityId = binaryCallCapabilityId msg
+        , callThreadId = binaryCallThreadId msg
+        , callStack = items
+        }
     , errors
     )
 
@@ -207,48 +217,59 @@ chunkCallStackMessage chunkSize msg0 =
     chunked = chunksOf (word16ToInt chunkSize) items
   in
     go chunked
-
-  where
-    mkCallStack chunk = MkBinaryCallStackMessage
+ where
+  mkCallStack chunk =
+    MkBinaryCallStackMessage
       { binaryCallThreadId = binaryCallThreadId msg0
       , binaryCallCapabilityId = binaryCallCapabilityId msg0
       , binaryCallStack = chunk
       }
 
-    go :: [[BinaryStackItem]] -> [BinaryEventlogMessage]
-    go [] =
-      -- If there are no chunks, we simply return the original message
-      [ CallStackFinal msg0
-      ]
-    go [chunk] =
-      [ CallStackFinal $ mkCallStack chunk
-      ]
-    go (chunk:chunks) =
-      CallStackChunk (mkCallStack chunk) : go chunks
+  go :: [[BinaryStackItem]] -> [BinaryEventlogMessage]
+  go [] =
+    -- If there are no chunks, we simply return the original message
+    [ CallStackFinal msg0
+    ]
+  go [chunk] =
+    [ CallStackFinal $ mkCallStack chunk
+    ]
+  go (chunk : chunks) =
+    CallStackChunk (mkCallStack chunk) : go chunks
 
 -- ----------------------------------------------------------------------------
 -- Helper types and functions to implement the conversion to the binary
 -- representation.
 -- ----------------------------------------------------------------------------
 
-data EncodingState tbl =
-  MkEncodingState
-    { symbolTableWriter :: SymbolTableWriter tbl
-    , stringMessages :: [BinaryStringMessage]
-    , sourceLocMessages :: [BinarySourceLocationMessage]
-    }
+data EncodingState tbl = MkEncodingState
+  { symbolTableWriter :: !(SymbolTableWriter tbl)
+  , stringMessages :: ![BinaryStringMessage]
+  , sourceLocMessages :: ![BinarySourceLocationMessage]
+  }
   deriving (Generic)
 
+runWithEncodingState :: EncodingState tbl -> State (EncodingState tbl) a -> (a, EncodingState tbl)
+runWithEncodingState encodingState encoder =
+  runState encoder encodingState
+
+newEncodingState :: SymbolTableWriter tbl -> EncodingState tbl
+newEncodingState msgTbl0 =
+  MkEncodingState
+    { symbolTableWriter = msgTbl0
+    , stringMessages = []
+    , sourceLocMessages = []
+    }
+
 setSymbolTableWriter :: tbl -> State.State (EncodingState tbl) ()
-setSymbolTableWriter tbl = State.modify' (\ st -> st { symbolTableWriter = (symbolTableWriter st) { writerTable = tbl } })
+setSymbolTableWriter tbl = State.modify' (\st -> st{symbolTableWriter = (symbolTableWriter st){writerTable = tbl}})
 
 addStringMessage :: BinaryStringMessage -> State.State (EncodingState tbl) ()
-addStringMessage msg = State.modify' (\ st -> st { stringMessages = msg : stringMessages st })
+addStringMessage msg = State.modify' (\st -> st{stringMessages = msg : stringMessages st})
 
 addSourceLocationMessage :: BinarySourceLocationMessage -> State.State (EncodingState tbl) ()
-addSourceLocationMessage msg = State.modify' (\ st -> st { sourceLocMessages = msg : sourceLocMessages st })
+addSourceLocationMessage msg = State.modify' (\st -> st{sourceLocMessages = msg : sourceLocMessages st})
 
-lookupOrInsertTextMessage :: forall tbl . Text -> State (EncodingState tbl) (StringId, Bool)
+lookupOrInsertTextMessage :: forall tbl. Text -> State (EncodingState tbl) (StringId, Bool)
 lookupOrInsertTextMessage s = do
   tbl <- State.gets symbolTableWriter
   let
@@ -256,7 +277,7 @@ lookupOrInsertTextMessage s = do
   setSymbolTableWriter tbl1
   pure (sid, new)
 
-lookupOrInsertSrcLocMessage :: forall tbl . SourceLocation -> State (EncodingState tbl) (SourceLocationId, Bool)
+lookupOrInsertSrcLocMessage :: forall tbl. SourceLocation -> State (EncodingState tbl) (SourceLocationId, Bool)
 lookupOrInsertSrcLocMessage s = do
   tbl <- State.gets symbolTableWriter
   let
@@ -264,24 +285,26 @@ lookupOrInsertSrcLocMessage s = do
   setSymbolTableWriter tbl1
   pure (sid, new)
 
-lookupTextMessage :: forall tbl . Text -> State (EncodingState tbl) StringId
+lookupTextMessage :: forall tbl. Text -> State (EncodingState tbl) StringId
 lookupTextMessage s = do
   (sid, new) <- lookupOrInsertTextMessage s
   when new $
-    addStringMessage $ MkBinaryStringMessage sid s
+    addStringMessage $
+      MkBinaryStringMessage sid s
   pure sid
 
-lookupSourceLocationMessage :: forall tbl . SourceLocation -> State (EncodingState tbl) SourceLocationId
+lookupSourceLocationMessage :: forall tbl. SourceLocation -> State (EncodingState tbl) SourceLocationId
 lookupSourceLocationMessage s = do
   (sid, new) <- lookupOrInsertSrcLocMessage s
   when new $ do
     nameId <- lookupTextMessage $ functionName s
     fileId <- lookupTextMessage $ fileName s
-    addSourceLocationMessage $ MkBinarySourceLocationMessage
-      { binarySourceLocationMessageId = sid
-      , binarySourceLocationRow = line s
-      , binarySourceLocationColumn = column s
-      , binarySourceLocationFunctionId = nameId
-      , binarySourceLocationFilename = fileId
-      }
+    addSourceLocationMessage $
+      MkBinarySourceLocationMessage
+        { binarySourceLocationMessageId = sid
+        , binarySourceLocationRow = line s
+        , binarySourceLocationColumn = column s
+        , binarySourceLocationFunctionId = nameId
+        , binarySourceLocationFilename = fileId
+        }
   pure sid

--- a/ghc-stack-profiler-core/src/GHC/Stack/Profiler/Core/Util.hs
+++ b/ghc-stack-profiler-core/src/GHC/Stack/Profiler/Core/Util.hs
@@ -2,24 +2,24 @@ module GHC.Stack.Profiler.Core.Util where
 
 import Control.Monad (replicateM)
 import Data.Binary
-import Data.Binary.Put
 import Data.Binary.Get
-import Data.Coerce (coerce, Coercible)
+import Data.Binary.Put
+import Data.Coerce (Coercible, coerce)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Numeric
 
-idToInt :: Coercible a Word64 => a -> Int
+idToInt :: (Coercible a Word64) => a -> Int
 idToInt = word64ToInt . coerce
 
 putTextWord16 :: Word16 -> Text -> Put
 putTextWord16 bound msg =
   putWord16 len <> putStringUtf8 (Text.unpack msg)
-  where
-    shortName = Text.take (word16ToInt bound) msg
-    -- this is safe as 'bound' is a 'Word16' itself
-    -- so the short string can be at most have a length of 'Word16'
-    len = intToWord16 $ Text.length shortName
+ where
+  shortName = Text.take (word16ToInt bound) msg
+  -- this is safe as 'bound' is a 'Word16' itself
+  -- so the short string can be at most have a length of 'Word16'
+  len = intToWord16 $ Text.length shortName
 
 getTextWord16 :: Get Text
 getTextWord16 = do
@@ -27,7 +27,7 @@ getTextWord16 = do
   s <- replicateM (word16ToInt len) get
   pure $ Text.pack s
 
-showAsHex :: Integral a => a -> String
+showAsHex :: (Integral a) => a -> String
 showAsHex d = "0x" ++ Numeric.showHex d ""
 
 putWord64 :: Word64 -> Put

--- a/ghc-stack-profiler/ghc-stack-profiler.cabal
+++ b/ghc-stack-profiler/ghc-stack-profiler.cabal
@@ -104,11 +104,13 @@ library
     GHC.Internal.Stack.Decode.Compat
     GHC.Stack.Annotation.Experimental.Compat
     GHC.Stack.Profiler
+    GHC.Stack.Profiler.Commands
     GHC.Stack.Profiler.Decode
     GHC.Stack.Profiler.FFI
     GHC.Stack.Profiler.Manager
     GHC.Stack.Profiler.Stack.Compat
     GHC.Stack.Profiler.Stack.Decode
+    GHC.Stack.Profiler.SymbolTable
     GHC.Stack.Profiler.Util
 
   build-depends:

--- a/ghc-stack-profiler/src/Debug/Trace/Binary/Compat.hs
+++ b/ghc-stack-profiler/src/Debug/Trace/Binary/Compat.hs
@@ -1,12 +1,14 @@
-{-# LANGUAGE CPP           #-}
-{-# LANGUAGE MagicHash     #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
+
 module Debug.Trace.Binary.Compat (
   -- * For tracing user binary events
   traceBinaryEventIO,
+
   -- * Flag to check whether the eventlog is enabled
-  userTracingEnabled,
-  ) where
+  userTracingEnabledIO,
+) where
 
 #if defined(USE_GHC_TRACE_EVENTS)
 import Debug.Trace.Binary (traceBinaryEventIO)
@@ -18,7 +20,12 @@ import GHC.Types (IO(..))
 import GHC.Exts (Ptr(..), Int(..), traceBinaryEvent#)
 import GHC.Internal.RTS.Flags.Test (getUserEventTracingEnabled)
 import System.IO.Unsafe (unsafePerformIO)
+#endif
 
+#if defined(USE_GHC_TRACE_EVENTS)
+userTracingEnabledIO :: IO Bool
+userTracingEnabledIO = pure userTracingEnabled
+#else
 traceBinaryEventIO :: B.ByteString -> IO ()
 traceBinaryEventIO bytes = traceBinaryEventIO' bytes
 
@@ -28,6 +35,6 @@ traceBinaryEventIO' bytes =
     case traceBinaryEvent# p n s of
       s' -> (# s', () #)
 
-userTracingEnabled :: Bool
-userTracingEnabled = unsafePerformIO getUserEventTracingEnabled
+userTracingEnabledIO :: IO Bool
+userTracingEnabledIO = getUserEventTracingEnabled
 #endif

--- a/ghc-stack-profiler/src/GHC/Internal/Heap/Closures/Compat.hs
+++ b/ghc-stack-profiler/src/GHC/Internal/Heap/Closures/Compat.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
+
 module GHC.Internal.Heap.Closures.Compat (
-  Box(..),
+  Box (..),
 ) where
 
 #if MIN_VERSION_ghc_internal(9,1400,0)

--- a/ghc-stack-profiler/src/GHC/Internal/Stack/Constants/Compat.hs
+++ b/ghc-stack-profiler/src/GHC/Internal/Stack/Constants/Compat.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
+
 module GHC.Internal.Stack.Constants.Compat (
-  WordOffset(..),
+  WordOffset (..),
   offsetStgAnnFrameAnn,
 ) where
 
@@ -16,4 +17,3 @@ import GHC.Exts.Stack.Constants
 offsetStgAnnFrameAnn :: WordOffset
 offsetStgAnnFrameAnn = error "offsetStgAnnFrameAnn is only available in GHC >=9.14"
 #endif
-

--- a/ghc-stack-profiler/src/GHC/Internal/Stack/Decode/Compat.hs
+++ b/ghc-stack-profiler/src/GHC/Internal/Stack/Decode/Compat.hs
@@ -1,30 +1,32 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE GHCForeignImportPrim #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
-{-# LANGUAGE GHCForeignImportPrim #-}
 {-# LANGUAGE UnliftedFFITypes #-}
-{-# LANGUAGE CPP #-}
+
 module GHC.Internal.Stack.Decode.Compat (
   StackFrameLocation,
   StackSnapshot#,
-  StackInfoTable(..),
+  StackInfoTable (..),
   getInfoTableForStack,
   getInfoTableOnStack,
   advanceStackFrameLocation,
   stackHead,
-  Box(..),
+  Box (..),
   getClosureBox,
 ) where
 
 import GHC.Exts
 import GHC.Stack.CloneStack (StackSnapshot (..))
+
 -- See Note [No way-dependent imports]
 #if defined(PROFILING)
 import GHC.Exts.Heap.InfoTableProf
 #else
 import GHC.Exts.Heap.InfoTable
 #endif
-import qualified GHC.Internal.InfoProv.Types as InfoProv
 import GHC.Internal.Heap.Closures.Compat
+import qualified GHC.Internal.InfoProv.Types as InfoProv
 import GHC.Internal.Stack.Constants.Compat (WordOffset)
 
 {-
@@ -52,16 +54,18 @@ data StackInfoTable = StackInfoTable
 -- Additionally, provides 'InfoProv' for the 'StgInfoTable' if there is any.
 getInfoTableOnStack :: StackSnapshot# -> WordOffset -> IO StackInfoTable
 getInfoTableOnStack stackSnapshot# index = do
-  let !(# itbl_struct#, itbl_ptr_ipe_key# #) = getInfoTableAddrs# stackSnapshot# (wordOffsetToWord# index)
-      itbl_struct = Ptr itbl_struct#
-      itbl_ptr = Ptr itbl_ptr_ipe_key#
+  let
+    !(# itbl_struct#, itbl_ptr_ipe_key# #) = getInfoTableAddrs# stackSnapshot# (wordOffsetToWord# index)
+    itbl_struct = Ptr itbl_struct#
+    itbl_ptr = Ptr itbl_ptr_ipe_key#
 
   itbl <- peekItbl itbl_struct
-  pure StackInfoTable
-    { infoTableStructPtr = itbl_struct
-    , infoTablePtr = itbl_ptr
-    , infoTable = itbl
-    }
+  pure
+    StackInfoTable
+      { infoTableStructPtr = itbl_struct
+      , infoTablePtr = itbl_ptr
+      , infoTable = itbl
+      }
 
 getInfoTableForStack :: StackSnapshot# -> IO StgInfoTable
 getInfoTableForStack stackSnapshot# =
@@ -71,13 +75,15 @@ getInfoTableForStack stackSnapshot# =
 -- | Advance to the next stack frame (if any)
 advanceStackFrameLocation :: StackFrameLocation -> Maybe StackFrameLocation
 advanceStackFrameLocation (StackSnapshot stackSnapshot#, index) =
-  let !(# s', i', hasNext #) = advanceStackFrameLocation# stackSnapshot# (wordOffsetToWord# index)
-   in if I# hasNext > 0
-        then Just (StackSnapshot s', primWordToWordOffset i')
-        else Nothing
-  where
-    primWordToWordOffset :: Word# -> WordOffset
-    primWordToWordOffset w# = fromIntegral (W# w#)
+  let
+    !(# s', i', hasNext #) = advanceStackFrameLocation# stackSnapshot# (wordOffsetToWord# index)
+  in
+    if I# hasNext > 0
+      then Just (StackSnapshot s', primWordToWordOffset i')
+      else Nothing
+ where
+  primWordToWordOffset :: Word# -> WordOffset
+  primWordToWordOffset w# = fromIntegral (W# w#)
 
 -- | `StackFrameLocation` of the top-most stack frame
 stackHead :: StackSnapshot# -> StackFrameLocation
@@ -104,7 +110,7 @@ foreign import prim "getStackInfoTableAddrzh"
   getStackInfoTableAddr# :: StackSnapshot# -> Addr#
 
 foreign import prim "getStackClosurezh"
-  getStackClosure# :: StackSnapshot# -> Word# ->  Any
+  getStackClosure# :: StackSnapshot# -> Word# -> Any
 
 -- ----------------------------------------------------------------------------
 -- Utilities that really should live somewhere else

--- a/ghc-stack-profiler/src/GHC/Stack/Annotation/Experimental/Compat.hs
+++ b/ghc-stack-profiler/src/GHC/Stack/Annotation/Experimental/Compat.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
+
 module GHC.Stack.Annotation.Experimental.Compat (
-  SomeStackAnnotation(..),
-  CallStackAnnotation(..),
-  StringAnnotation(..),
+  SomeStackAnnotation (..),
+  CallStackAnnotation (..),
+  StringAnnotation (..),
 ) where
 
 #if MIN_VERSION_ghc_internal(9,1400,0)

--- a/ghc-stack-profiler/src/GHC/Stack/Profiler.hs
+++ b/ghc-stack-profiler/src/GHC/Stack/Profiler.hs
@@ -3,8 +3,8 @@ module GHC.Stack.Profiler (
   withStackProfiler,
   withStackProfilerForMyThread,
   withStackProfilerForThread,
-  setupRootStackProfiler,
-  stopStackProfilerManager,
+  withRootStackProfiler,
+  shutdownStackProfilerManager,
 
   -- * Configuration of sample profiler
   StackProfilerManager (..),
@@ -13,42 +13,45 @@ module GHC.Stack.Profiler (
   -- * Basic thread sampler
   sampleThread,
 
-  -- * Low level helpers for setting up custom
-
-  -- sample profilers threads
+  -- * Low level helpers for setting up custom sample profilers threads
   runWithStackProfiler,
   setupStackProfilerThread,
   stopStackProfilerThread,
-  sampleToEventlog,
 
   -- * Thread filtering
   isProfilerThread,
   isRtsThread,
 ) where
 
-import Control.Concurrent
-import Control.Exception
-import Control.Monad
-import qualified Data.ByteString.Lazy as LBS
-import qualified Data.List as List
 import GHC.Conc
 import GHC.Conc.Sync (fromThreadId, threadLabel)
-
 import GHC.Stack.CloneStack (cloneThreadStack)
 
+import Control.Concurrent
 import Control.Concurrent.Async
+import qualified Control.Concurrent.Chan as Chan
 import qualified Control.Concurrent.STM.TVar as STM
+import Control.Exception
+import Control.Monad
 import qualified Control.Monad.STM as STM
+import qualified Data.ByteString.Lazy as LBS
 import Data.Foldable (traverse_)
+import qualified Data.List as List
+import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
+import qualified Debug.Trace
 import qualified Debug.Trace.Binary.Compat as Compat
+
+import GHC.Stack.Profiler.Commands (sendStopProfilingMessage)
 import GHC.Stack.Profiler.Core.Eventlog
 import GHC.Stack.Profiler.Core.ThreadSample
 import GHC.Stack.Profiler.Core.Util
 import GHC.Stack.Profiler.Decode
+import qualified GHC.Stack.Profiler.Decode as Decode
 import qualified GHC.Stack.Profiler.FFI as FFI
 import GHC.Stack.Profiler.Manager
+import GHC.Stack.Profiler.SymbolTable (readSymbolTable)
 
 -- | Sampling intervals for the stack profiler.
 data ProfilerSamplingInterval
@@ -74,24 +77,11 @@ profilerSamplingIntervalToThreadDelayTime = \case
 -- are usually not interesting for user code.
 withStackProfiler :: StackProfilerManager -> ProfilerSamplingInterval -> IO a -> IO a
 withStackProfiler manager delay act = do
-  runWithStackProfiler manager sampleAction delay act
- where
-  sampleAction = do
-    tids <- listThreads
-    userThreads <- filterM (isThreadOfInterest manager) tids
-    forM_ userThreads $ \tid ->
-      sampleToEventlog manager tid
-
-  isThreadOfInterest :: StackProfilerManager -> ThreadId -> IO Bool
-  isThreadOfInterest config tid = do
-    lbl <- threadLabel tid
-    (_, threadIds) <- readTVarIO (profilerThreads config)
-    pure $
-      not $
-        or
-          [ isProfilerThread threadIds tid
-          , isRtsThread tid lbl
-          ]
+  runWithStackProfiler
+    manager
+    (allThreadSampler manager delay)
+    (defaultCallStackSerialiser manager)
+    act
 
 -- | Sample the current thread every 'ProfilerSamplingInterval' for the duration of
 -- the wrapped action.
@@ -106,79 +96,156 @@ withStackProfilerForMyThread manager delay act = do
 -- Once the wrapped action terminates, the stack profiling stops.
 withStackProfilerForThread :: StackProfilerManager -> ThreadId -> ProfilerSamplingInterval -> IO a -> IO a
 withStackProfilerForThread manager tid delay act =
-  runWithStackProfiler manager (sampleToEventlog manager tid) delay act
-
-setupRootStackProfiler :: Bool -> (StackProfilerManager -> IO a) -> IO ()
-setupRootStackProfiler shouldRun act =
-  bracket
-    ( do
-        manager <- newStackProfilerManager shouldRun
-        FFI.installEventlogSocketHandlers manager
-        pure manager
-    )
+  runWithStackProfiler
+    manager
+    (singleThreadSampler manager delay tid)
+    (defaultCallStackSerialiser manager)
     act
-    stopStackProfilerManager
+
+withRootStackProfiler :: Bool -> (StackProfilerManager -> IO a) -> IO a
+withRootStackProfiler shouldRun act =
+  bracket
+    (runNewStackProfilerManager shouldRun)
+    shutdownStackProfilerManager
+    act
 
 -- ----------------------------------------------------------------------------
 -- Low-level user API
 -- ----------------------------------------------------------------------------
 
-runWithStackProfiler :: StackProfilerManager -> IO () -> ProfilerSamplingInterval -> IO a -> IO a
-runWithStackProfiler manager sampleAction delay act = do
-  if Compat.userTracingEnabled
-    then bracket (setupStackProfilerThread manager sampleAction delay) (uncurry stopStackProfilerThread) (const act)
-    else act
+runNewStackProfilerManager :: Bool -> IO StackProfilerManager
+runNewStackProfilerManager shouldRun = do
+  manager <- newStackProfilerManager shouldRun
+  startEventLoopThread manager
+  FFI.installEventlogSocketHandlers manager `catches` FFI.defaultErrorHandlers
+  pure manager
 
-stopStackProfilerManager :: StackProfilerManager -> IO ()
-stopStackProfilerManager MkStackProfilerManager{isShuttingDown, profilerThreads} = do
-  (threads, _) <- atomically $ do
-    writeTVar isShuttingDown True
-    readTVar profilerThreads
-  traverse_ cancel threads
+shutdownStackProfilerManager :: StackProfilerManager -> IO ()
+shutdownStackProfilerManager manager = do
+  shutdownAllSamplerThreads manager
+  -- TODO: we could also send a stop command instead
+  shutdownEventLoop manager
 
-stopStackProfilerThread :: Async () -> StackProfilerManager -> IO ()
-stopStackProfilerThread profilerThread MkStackProfilerManager{profilerThreads} = do
+runWithStackProfiler :: StackProfilerManager -> ThreadSampler -> CallStackSerialiser -> IO a -> IO a
+runWithStackProfiler manager sampler serializer act = do
+  bracket
+    (setupStackProfilerThread manager sampler serializer)
+    (stopStackProfilerThread manager)
+    (const act)
+
+stopStackProfilerThread :: StackProfilerManager -> Async () -> IO ()
+stopStackProfilerThread MkStackProfilerManager{profilerThreads} profilerThread = do
   cancel profilerThread
     `finally` atomically
       ( do
-        STM.modifyTVar' profilerThreads ( \ ( threads, threadIds) ->
-            (Set.delete profilerThread threads, Set.delete (asyncThreadId profilerThread) threadIds))
+          STM.modifyTVar'
+            profilerThreads
+            ( \threadMap ->
+                (Map.delete (asyncThreadId profilerThread) threadMap)
+            )
       )
 
-setupStackProfilerThread :: StackProfilerManager -> IO () -> ProfilerSamplingInterval -> IO (Async (), StackProfilerManager)
-setupStackProfilerThread manager sampleAction delay = do
+setupStackProfilerThread ::
+  StackProfilerManager ->
+  ThreadSampler ->
+  CallStackSerialiser ->
+  IO (Async ())
+setupStackProfilerThread manager sampler serialiser = do
   barrier <- newEmptyMVar
-  worker <- async $ do
+  workerThread <- async $ do
     () <- takeMVar barrier
     sampleThreadId <- myThreadId
     labelThread sampleThreadId ("Sample Profiler Thread " <> show (fromThreadId sampleThreadId))
     forever $ do
-      atomically $ do
-        STM.check =<< readTVar (isRunning manager)
-      sampleAction
-      -- TODO: this is wrong, we don't sample every delay time as sampling takes time as well
-      threadDelay (profilerSamplingIntervalToThreadDelayTime delay)
+      runStackProfilerSample sampler serialiser
 
-  -- if the worker crashes for any reason, we want to know
-  link worker
-
-  atomically $ do
-    STM.modifyTVar' (profilerThreads manager) $ \(threads, threadIds) ->
-      (Set.insert worker threads, Set.insert (asyncThreadId worker) threadIds)
+  -- Add this thread to the list of known worker threads to make sure it isn't accidentally sampled
+  addSamplerThread manager workerThread
   putMVar barrier ()
-  pure (worker, manager)
+  pure workerThread
 
--- | We don't want to sample the stack profiler threads themselves.
-isProfilerThread :: Set ThreadId -> ThreadId -> Bool
-isProfilerThread profilerThreadIds tid =
-  Set.member tid profilerThreadIds
+-- ----------------------------------------------------------------------------
+-- Sample the RTS CallStack of one or more threads
+-- ----------------------------------------------------------------------------
 
--- | RTS threads are often not that interesting, we much rather want to focus on
--- the user code.
-isRtsThread :: ThreadId -> Maybe String -> Bool
-isRtsThread _ Nothing = False
-isRtsThread _tid (Just lbl) =
-  lbl == "TimerManager" || "IOManager on cap" `List.isPrefixOf` lbl
+data ThreadSampler = MkThreadSampler
+  { listThreadsToSample :: IO [ThreadId]
+  , delaySamplerThread :: IO ()
+  , waitForProfilingStart :: IO ()
+  }
+
+defaultThreadSampler :: StackProfilerManager -> ProfilerSamplingInterval -> ThreadSampler
+defaultThreadSampler manager delay =
+  MkThreadSampler
+    { listThreadsToSample = do
+        pure []
+    , delaySamplerThread =
+        threadDelay (profilerSamplingIntervalToThreadDelayTime delay)
+    , waitForProfilingStart =
+        atomically $ do
+          STM.check =<< shouldProfile manager
+    }
+
+singleThreadSampler :: StackProfilerManager -> ProfilerSamplingInterval -> ThreadId -> ThreadSampler
+singleThreadSampler manager delay tid =
+  (defaultThreadSampler manager delay)
+    { listThreadsToSample = do
+        pure [tid]
+    }
+
+allThreadSampler :: StackProfilerManager -> ProfilerSamplingInterval -> ThreadSampler
+allThreadSampler manager delay =
+  (defaultThreadSampler manager delay)
+    { listThreadsToSample = do
+        tids <- listThreads
+        userThreads <- filterM (isThreadOfInterest manager) tids
+        pure userThreads
+    }
+
+runStackProfilerSample :: ThreadSampler -> CallStackSerialiser -> IO ()
+runStackProfilerSample sampler serialiser = do
+  waitForProfilingStart sampler
+  tids <- listThreadsToSample sampler
+  mapM_ (runCallStackSerialiser serialiser) tids
+  -- TODO: this is wrong, we don't sample every delay time as sampling takes time as well
+  delaySamplerThread sampler
+
+-- ----------------------------------------------------------------------------
+-- Serialise the RTS CallStack for the eventlog
+-- ----------------------------------------------------------------------------
+
+data CallStackSerialiser = MkCallStackSerialiser
+  { sampleCallStack :: ThreadId -> IO (Maybe ThreadSample)
+  , decodeThreadSample :: ThreadSample -> IO CallStackMessage
+  , serialiseCallStackMessage :: CallStackMessage -> IO ()
+  }
+
+-- | If the thread's callstack can be sampled, we serialise the sample
+-- and write into the eventlog for later processing.
+runCallStackSerialiser :: CallStackSerialiser -> ThreadId -> IO ()
+runCallStackSerialiser serialiser tid = do
+  sampleCallStack serialiser tid >>= \case
+    Nothing -> pure ()
+    Just threadSample -> do
+      callStackSample <- decodeThreadSample serialiser threadSample
+      serialiseCallStackMessage serialiser callStackSample
+
+defaultCallStackSerialiser :: StackProfilerManager -> CallStackSerialiser
+defaultCallStackSerialiser manager =
+  MkCallStackSerialiser
+    { sampleCallStack = sampleThread
+    , decodeThreadSample = threadSampleToCallStackMessage
+    , serialiseCallStackMessage = \callStackSample -> do
+        lbss <- atomically $ do
+          eventlogMessages <- serializeCallStackMessage (symbolTableRef manager) callStackSample
+          let
+            lbss = serializeBinaryEventlogMessages eventlogMessages
+          -- Only write this message if we are still profiling
+          STM.check =<< shouldProfile manager
+          pure lbss
+
+        writeChan (messageChan manager) (WriteProfileSample $ fmap LBS.toStrict lbss)
+    }
 
 -- | Sample the stack of the 'ThreadId' if the thread is currently running.
 -- If the thread is not running (e.g., because it is dead), then we return 'Nothing'.
@@ -206,12 +273,121 @@ sampleThread tid = do
     ThreadBlocked BlockedOnMVar -> True
     _ -> False
 
--- | If the thread's callstack can be sampled, we serialise the sample
--- and write into the eventlog for later processing.
-sampleToEventlog :: StackProfilerManager -> ThreadId -> IO ()
-sampleToEventlog manager tid = do
-  sampleThread tid >>= \case
-    Nothing -> pure ()
-    Just threadSample -> do
-      msgs <- serializeThreadSample (symbolTableRef manager) threadSample
-      mapM_ (Compat.traceBinaryEventIO . LBS.toStrict) msgs
+-- ----------------------------------------------------------------------------
+-- Main Event Loop handler
+-- ----------------------------------------------------------------------------
+
+startEventLoopThread :: StackProfilerManager -> IO ()
+startEventLoopThread manager = do
+  !sinkAsync <- do
+    sinkAsync <- async (forever mainEventHandler)
+
+    -- if the main eventloop crashes for any reason, we want to know
+    link sinkAsync
+
+    pure
+      MkEventThread
+        { eventThread = sinkAsync
+        }
+
+  atomically $ do
+    writeTVar (mainEventLoopThread manager) (Just sinkAsync)
+ where
+  mainEventHandler = do
+    msg <- Chan.readChan (messageChan manager)
+    run <- STM.atomically $ shouldProfile manager
+    case msg of
+      WriteProfileSample msgs ->
+        case run of
+          True ->
+            mapM_ Compat.traceBinaryEventIO msgs
+          False ->
+            -- If we received a sample but the eventlog is currently locked
+            -- discard the message.
+            pure ()
+      StartProfiling barrier -> do
+        STM.atomically $ enableSampling manager
+        putMVar barrier ()
+      StopProfiling barrier -> do
+        STM.atomically $ disableSampling manager
+        putMVar barrier ()
+      StartEventlog barrier -> do
+        STM.atomically $ enableEventLogging manager
+        putMVar barrier ()
+      StopEventlog barrier -> do
+        STM.atomically $ disableEventLogging manager
+        putMVar barrier ()
+      PublishInitEvents barrier -> do
+        symbolTable <- STM.atomically $ readSymbolTable (symbolTableRef manager)
+        let
+          msgs = Decode.initMessages symbolTable
+
+        mapM_
+          Compat.traceBinaryEventIO
+          (fmap LBS.toStrict msgs)
+
+        Debug.Trace.flushEventLog
+        putMVar barrier ()
+
+---------------------------------------------------------------------
+-- Coordination utils
+-- ----------------------------------------------------------------------------
+
+shutdownEventLoop :: StackProfilerManager -> IO ()
+shutdownEventLoop manager = do
+  sinkAsync <- atomically $ do
+    thread <- readTVar (mainEventLoopThread manager)
+    writeTVar (mainEventLoopThread manager) Nothing
+    pure thread
+
+  sendStopProfilingMessage manager
+  traverse_ (cancel . eventThread) sinkAsync
+
+addSamplerThread :: StackProfilerManager -> Async () -> IO ()
+addSamplerThread manager worker = do
+  -- if the worker crashes for any reason, we want to know
+  link worker
+
+  atomically $ do
+    STM.modifyTVar' (profilerThreads manager) $ \threadMap ->
+      (Map.insert (asyncThreadId worker) worker threadMap)
+
+shutdownAllSamplerThreads :: StackProfilerManager -> IO ()
+shutdownAllSamplerThreads MkStackProfilerManager{profilerThreads} = do
+  threads <- atomically $ do
+    threadsMap <- readTVar profilerThreads
+    writeTVar profilerThreads Map.empty
+    pure $ Map.elems threadsMap
+
+  traverse_ cancel threads
+
+-- ----------------------------------------------------------------------------
+-- Utils
+-- ----------------------------------------------------------------------------
+
+-- | We don't want to sample the stack profiler threads themselves.
+isProfilerThread :: Maybe EventThread -> Set ThreadId -> ThreadId -> Bool
+isProfilerThread writerThread profilerThreadIds tid =
+  Set.member tid profilerThreadIds
+    || maybe False (== tid) (asyncThreadId . eventThread <$> writerThread)
+
+-- | RTS threads are often not that interesting, we much rather want to focus on
+-- the user code.
+isRtsThread :: ThreadId -> Maybe String -> Bool
+isRtsThread _ Nothing = False
+isRtsThread _tid (Just lbl) =
+  lbl == "TimerManager" || "IOManager on cap" `List.isPrefixOf` lbl
+
+isThreadOfInterest :: StackProfilerManager -> ThreadId -> IO Bool
+isThreadOfInterest manager tid = do
+  lbl <- threadLabel tid
+  (profilerThreadIds, eventlogWriter) <- STM.atomically $ do
+    threadMap <- readTVar (profilerThreads manager)
+    sink <- readTVar (mainEventLoopThread manager)
+    pure (Map.keysSet threadMap, sink)
+  pure $
+    not $
+      or
+        [ isProfilerThread eventlogWriter profilerThreadIds tid
+        , isRtsThread tid lbl
+        ]

--- a/ghc-stack-profiler/src/GHC/Stack/Profiler/Commands.hs
+++ b/ghc-stack-profiler/src/GHC/Stack/Profiler/Commands.hs
@@ -1,0 +1,96 @@
+module GHC.Stack.Profiler.Commands (
+  startProfiling,
+  stopProfiling,
+  sendPublishInitEventMessages,
+  sendStartProfilingMessage,
+  sendStopProfilingMessage,
+  sendEnableEventlogMessage,
+  sendDisableEventlogMessage,
+) where
+
+import Control.Concurrent.Chan
+import qualified Control.Concurrent.MVar as MVar
+import qualified Control.Concurrent.STM as STM
+import GHC.Stack.Profiler.Manager
+
+-- | Start the profiler threads.
+--
+-- Blocks until all threads started running.
+startProfiling :: StackProfilerManager -> IO ()
+startProfiling manager = do
+  -- TODO: this atomically is redundant, the main loop thread
+  -- sets it anyway
+  STM.atomically $
+    STM.writeTVar (isThreadSamplerRunning manager) True
+  sendStartProfilingMessage manager
+
+-- | Stop the running profiler threads.
+--
+-- Blocks until all threads stopped running.
+stopProfiling :: StackProfilerManager -> IO ()
+stopProfiling manager = do
+  -- TODO: this atomically is *not* redundant, it makes sure no new
+  -- samples can be created.
+  -- Otherwise, new samples could be created and queued while we are waiting
+  -- for the event loop to process this message.
+  -- It is important, that once this message is processed, that no sampler thread is sampling
+  -- at all. Otherwise, there will be new init events that are not published.
+  STM.atomically $
+    STM.writeTVar (isThreadSamplerRunning manager) False
+  sendStopProfilingMessage manager
+
+-- | Start profiling.
+--
+-- Blocks until the message has been processed by the main event loop.
+sendStartProfilingMessage :: StackProfilerManager -> IO ()
+sendStartProfilingMessage manager = do
+  barrier <- MVar.newEmptyMVar
+  writeChan
+    (messageChan manager)
+    (StartProfiling barrier)
+  MVar.takeMVar barrier
+
+-- | Stop profiling.
+--
+-- Blocks until the message has been processed by the main event loop.
+sendStopProfilingMessage :: StackProfilerManager -> IO ()
+sendStopProfilingMessage manager = do
+  barrier <- MVar.newEmptyMVar
+  writeChan
+    (messageChan manager)
+    (StopProfiling barrier)
+  MVar.takeMVar barrier
+
+-- | Start EventLogging now.
+--
+-- Blocks until the message has been processed by the main event loop.
+sendEnableEventlogMessage :: StackProfilerManager -> IO ()
+sendEnableEventlogMessage manager = do
+  barrier <- MVar.newEmptyMVar
+  writeChan
+    (messageChan manager)
+    (StartEventlog barrier)
+  MVar.takeMVar barrier
+
+-- | Stop EventLogging now.
+--
+-- Blocks until the message has been processed by the main event loop.
+sendDisableEventlogMessage :: StackProfilerManager -> IO ()
+sendDisableEventlogMessage manager = do
+  barrier <- MVar.newEmptyMVar
+  writeChan
+    (messageChan manager)
+    (StopEventlog barrier)
+  MVar.takeMVar barrier
+
+-- | Publish all init messages so far.
+--
+-- Blocks until the init events have been written to the eventlog and
+-- eventlog was flushed.
+sendPublishInitEventMessages :: StackProfilerManager -> IO ()
+sendPublishInitEventMessages manager = do
+  barrier <- MVar.newEmptyMVar
+  writeChan
+    (messageChan manager)
+    (PublishInitEvents barrier)
+  MVar.takeMVar barrier

--- a/ghc-stack-profiler/src/GHC/Stack/Profiler/Decode.hs
+++ b/ghc-stack-profiler/src/GHC/Stack/Profiler/Decode.hs
@@ -1,12 +1,15 @@
 module GHC.Stack.Profiler.Decode (
-  SymbolTable,
-  serializeThreadSample,
+  StackSymbolTable,
+  SymbolTableWriter,
+  initMessages,
+  serializeCallStackMessage,
+  serializeBinaryEventlogMessage,
+  serializeBinaryEventlogMessages,
   threadSampleToCallStackMessage,
+  binaryEventlogDefinitions,
 ) where
 
-import Control.Concurrent.STM.TVar (TVar)
-import qualified Control.Concurrent.STM.TVar as TVar
-import qualified Control.Monad.STM as STM
+import Control.Concurrent.STM
 import Data.Binary
 import Data.Binary.Put
 import qualified Data.ByteString.Lazy as LBS
@@ -14,31 +17,81 @@ import qualified Data.List.NonEmpty as NonEmpty
 
 import GHC.Conc.Sync (fromThreadId)
 
+import Control.Exception (assert)
+import GHC.Stack.Profiler.Core.Eventlog
 import GHC.Stack.Profiler.Core.SymbolTable
 import GHC.Stack.Profiler.Core.ThreadSample
-import GHC.Stack.Profiler.Core.Eventlog
 import GHC.Stack.Profiler.Stack.Decode (decodeStackWithIpProvId)
+import GHC.Stack.Profiler.SymbolTable
 
-type SymbolTable = SymbolTableWriter MapTable
-
-serializeThreadSample :: TVar SymbolTable -> ThreadSample -> IO [LBS.ByteString]
-serializeThreadSample tableRef sample = do
-  eventlogMessages <- threadSampleToCallStackMessage tableRef sample
-  pure $ map (runPut . put) eventlogMessages
-
-threadSampleToCallStackMessage :: TVar SymbolTable -> ThreadSample -> IO [BinaryEventlogMessage]
-threadSampleToCallStackMessage tableRef sample = do
+threadSampleToCallStackMessage :: ThreadSample -> IO CallStackMessage
+threadSampleToCallStackMessage sample = do
   frames <- decodeStackWithIpProvId $ threadSampleStackSnapshot sample
-  -- removes immediate duplicates
-  let callStackItems = fmap NonEmpty.head $ NonEmpty.group frames
-  let callStackMessage = MkCallStackMessage
-        { callThreadId = fromThreadId $ threadSampleId sample
-        , callCapabilityId = threadSampleCapability sample
-        , callStack = callStackItems
-        }
-  -- TODO: Abstract TVar SymbolTable somehow
-  STM.atomically $ do
-    table <- TVar.readTVar tableRef
-    let (messages, newTable) = dehydrateCallStackMessage table callStackMessage
-    TVar.writeTVar tableRef newTable
-    pure messages
+  let
+    -- removes immediate duplicates
+    callStackItems = fmap NonEmpty.head $ NonEmpty.group frames
+
+  pure
+    MkCallStackMessage
+      { callThreadId = fromThreadId $ threadSampleId sample
+      , callCapabilityId = threadSampleCapability sample
+      , callStack = callStackItems
+      }
+
+serializeCallStackMessage :: StackSymbolTable -> CallStackMessage -> STM [BinaryEventlogMessage]
+serializeCallStackMessage tableRef callStackMessage = do
+  table <- readSymbolTable tableRef
+  let
+    (eventlogMessages, newTable) = dehydrateCallStackMessage table callStackMessage
+  writeSymbolTable newTable tableRef
+  pure eventlogMessages
+
+serializeBinaryEventlogMessage :: BinaryEventlogMessage -> LBS.ByteString
+serializeBinaryEventlogMessage = runPut . put
+
+serializeBinaryEventlogMessages :: [BinaryEventlogMessage] -> [LBS.ByteString]
+serializeBinaryEventlogMessages = map serializeBinaryEventlogMessage
+
+initMessages :: SymbolTableWriter MapTable -> [LBS.ByteString]
+initMessages symbolTable =
+  let
+    (stringDefs, srcLocDefs) = binaryEventlogDefinitions symbolTable
+    binaryEventlogMessages =
+      ( map StringDef stringDefs
+          ++ map SourceLocationDef srcLocDefs
+      )
+  in
+    serializeBinaryEventlogMessages binaryEventlogMessages
+
+binaryEventlogDefinitions :: SymbolTableWriter MapTable -> ([BinaryStringMessage], [BinarySourceLocationMessage])
+binaryEventlogDefinitions table =
+  let
+    knownStrings = getKnownStrings $ writerTable table
+    knownSrcLocs = getKnownSourceLocations $ writerTable table
+
+    stringDefs =
+      fmap (uncurry MkBinaryStringMessage) knownStrings
+
+    srcLocDefs =
+      map (uncurry go) knownSrcLocs
+  in
+    ( stringDefs
+    , srcLocDefs
+    )
+ where
+  go :: SourceLocationId -> SourceLocation -> BinarySourceLocationMessage
+  go sid s =
+    let
+      (funcId, newFuncName, _) = lookupOrInsertText table (writerTable table) (functionName s)
+      (fileId, newFileName, _) = lookupOrInsertText table (writerTable table) (fileName s)
+    in
+      -- These should always be found
+      assert (not newFuncName) $
+        assert (not newFileName) $
+          MkBinarySourceLocationMessage
+            { binarySourceLocationMessageId = sid
+            , binarySourceLocationRow = line s
+            , binarySourceLocationColumn = column s
+            , binarySourceLocationFunctionId = funcId
+            , binarySourceLocationFilename = fileId
+            }

--- a/ghc-stack-profiler/src/GHC/Stack/Profiler/FFI.hs
+++ b/ghc-stack-profiler/src/GHC/Stack/Profiler/FFI.hs
@@ -4,18 +4,18 @@
 
 module GHC.Stack.Profiler.FFI (
   installEventlogSocketHandlers,
-  startProfiler,
-  stopProfiler,
+  defaultErrorHandlers,
 ) where
 
-import GHC.Stack.Profiler.Manager
-import qualified Control.Monad.STM as STM
-import qualified Control.Concurrent.STM.TVar as TVar
 #if defined(EVENTLOG_SOCKET_SUPPORT)
-import Control.Exception
 import GHC.Eventlog.Socket
-import System.IO
+import System.IO (hPutStrLn, stderr)
 #endif
+
+import Control.Exception
+import qualified Control.Monad.STM as STM
+import GHC.Stack.Profiler.Manager
+import GHC.Stack.Profiler.Commands
 
 #if defined(EVENTLOG_SOCKET_SUPPORT)
 startProfilerCommandId :: CommandId
@@ -25,28 +25,72 @@ stopProfilerCommandId :: CommandId
 stopProfilerCommandId = CommandId 0x2
 #endif
 
+-- | Install the @eventlog-socket@ custom command handlers and lifecycle hooks.
+--
+-- The supported custom commands are:
+-- * Start the profiler
+-- * Stop the profiler
+--
+-- We implement the lifecycle hooks for stopping the eventlog and starting
+-- writing to the eventlog.
+-- When we start eventlogging, we post the definitions of the existing callstack
+-- definitions, e.g., string and source locations.
+--
+-- May throw 'EventlogSocketControlError' when registering @eventlog-socket@
+-- hooks fails.
 installEventlogSocketHandlers :: StackProfilerManager -> IO ()
-installEventlogSocketHandlers = do
+installEventlogSocketHandlers =
 #if defined(EVENTLOG_SOCKET_SUPPORT)
   \ manager -> do
-    success <- try $ do
+    registerEventlogSocketHooks manager
+  where
+    registerEventlogSocketHooks manager = do
+      registerHook HookPostStartEventLogging $
+        startEventLoggingHook manager
+      registerHook HookPreEndEventLogging $
+        endEventLoggingHook manager
       ns <- registerNamespace "ghc-stack-profiler"
-      registerCommand ns startProfilerCommandId (startProfiler manager)
-      registerCommand ns stopProfilerCommandId (stopProfiler manager)
-    case success of
-      Right () -> pure ()
-      Left (esce :: EventlogSocketControlError) -> do
-        hPutStrLn stderr "Failed to register eventlog-socket commands"
-        hPutStrLn stderr (displayException esce)
+      registerCommand ns startProfilerCommandId (startProfilerCommand manager)
+      registerCommand ns stopProfilerCommandId (stopProfilerCommand manager)
 #else
   \ _manager ->
     pure ()
 #endif
 
-startProfiler :: StackProfilerManager -> IO ()
-startProfiler manager = do
-  STM.atomically $ TVar.writeTVar (isRunning manager) True
+defaultErrorHandlers :: [Handler ()]
+defaultErrorHandlers =
+  [
+#if defined(EVENTLOG_SOCKET_SUPPORT)
+    Handler $ \ (e :: EventlogSocketControlError) -> do
+      hPutStrLn stderr "Failed to register eventlog-socket commands"
+      hPutStrLn stderr (displayException e)
+#endif
+  ]
 
-stopProfiler :: StackProfilerManager -> IO ()
-stopProfiler manager = do
-  STM.atomically $ TVar.writeTVar (isRunning manager) False
+-- | Post-start EventLogging hook.
+--
+-- 1. Publish init events and flush the eventlog.
+-- 2. Inform the main loop that the eventlog is ready for messages now.
+startEventLoggingHook :: StackProfilerManager -> IO ()
+startEventLoggingHook manager = do
+  sendPublishInitEventMessages manager
+  -- Block until start message has been processed
+  sendEnableEventlogMessage manager
+
+-- | Pre-end EventLogging hook.
+endEventLoggingHook :: StackProfilerManager -> IO ()
+endEventLoggingHook manager = do
+  -- Disallow logging any more messages to the eventlog.
+  -- Stops the profiler sampling threads.
+  STM.atomically $ disableEventLogging manager
+
+  -- Block until all messages have been processed
+  sendDisableEventlogMessage manager
+
+startProfilerCommand :: StackProfilerManager -> IO ()
+startProfilerCommand manager = do
+  startProfiling manager
+
+stopProfilerCommand :: StackProfilerManager -> IO ()
+stopProfilerCommand manager = do
+  stopProfiling manager

--- a/ghc-stack-profiler/src/GHC/Stack/Profiler/Manager.hs
+++ b/ghc-stack-profiler/src/GHC/Stack/Profiler/Manager.hs
@@ -1,31 +1,100 @@
 module GHC.Stack.Profiler.Manager (
   StackProfilerManager (..),
   newStackProfilerManager,
+  shouldProfile,
+  EventThread (..),
+  ProfilerMessage (..),
+  enableEventLogging,
+  disableEventLogging,
+  enableSampling,
+  disableSampling,
 ) where
 
 import Control.Concurrent (ThreadId)
 import Control.Concurrent.Async (Async)
+import Control.Concurrent.Chan
+import Control.Concurrent.MVar
+import Control.Concurrent.STM (STM)
 import Control.Concurrent.STM.TVar
-import Data.Set (Set)
-import qualified Data.Set as Set
-import GHC.Stack.Profiler.Core.SymbolTable (emptyMapSymbolTableWriter)
-import GHC.Stack.Profiler.Decode
+import qualified Control.Concurrent.STM.TVar as TVar
+import Data.ByteString (ByteString)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Debug.Trace.Binary.Compat as Compat
+import GHC.Generics (Generic)
+import GHC.Stack.Profiler.SymbolTable
 
 -- | A 'StackProfilerManager' records all the relevant information
 -- to manage the ghc stack profiler run-time.
 data StackProfilerManager = MkStackProfilerManager
-  { profilerThreads :: !(TVar (Set (Async ()), Set ThreadId))
+  { profilerThreads :: !(TVar (Map ThreadId (Async ())))
   -- ^ 'Async' of the stack sampling thread.
-  , symbolTableRef :: !(TVar SymbolTable)
-  , isRunning :: !(TVar Bool)
-  , isShuttingDown :: !(TVar Bool)
+  , mainEventLoopThread :: !(TVar (Maybe EventThread))
+  -- ^ Main event loop thread responsible for processing profiler messages, etc...
+  , symbolTableRef :: !StackSymbolTable
+  -- ^ Global table for common symbols.
+  , isThreadSamplerRunning :: !(TVar Bool)
+  -- ^ Is the profiler currently running?
+  --
+  -- Can be controlled via 'startProfiler' and 'stopProfiler'.
+  -- This variable describes whether the user wants to profile, regardless
+  -- of the eventlog state.
+  , isEventlogStarted :: !(TVar Bool)
+  -- ^ Is there an eventlog?
+  --
+  -- It is fully possible that we start profiling but no eventlog-writer
+  -- being connected/configured. The eventlog can be enabled at a later point,
+  -- or stopped/started via @eventlog-socket@.
+  -- This variable tracks the state of the eventlog-writer.
+  , messageChan :: Chan ProfilerMessage
   }
-  deriving (Eq)
+  deriving (Generic, Eq)
+
+data ProfilerMessage
+  = WriteProfileSample [ByteString]
+  | PublishInitEvents (MVar ())
+  | StartProfiling (MVar ())
+  | StopProfiling (MVar ())
+  | StartEventlog (MVar ())
+  | StopEventlog (MVar ())
 
 newStackProfilerManager :: Bool -> IO StackProfilerManager
 newStackProfilerManager running = do
+  tracingEnabled <- Compat.userTracingEnabledIO
   MkStackProfilerManager
-    <$> newTVarIO (Set.empty, Set.empty)
-    <*> newTVarIO emptyMapSymbolTableWriter
+    <$> newTVarIO Map.empty
+    <*> newTVarIO Nothing
+    <*> emptySymbolTableIO
     <*> newTVarIO running
-    <*> newTVarIO False
+    <*> newTVarIO tracingEnabled
+    <*> newChan
+
+data EventThread = MkEventThread
+  { eventThread :: !(Async ())
+  }
+
+-- | Can we profile right now?
+--
+-- We only sample a stack if the profiler is instructed to run and the eventlog is enabled.
+shouldProfile :: StackProfilerManager -> STM Bool
+shouldProfile manager =
+  liftA2
+    (&&)
+    (readTVar $ isThreadSamplerRunning manager)
+    (readTVar $ isEventlogStarted manager)
+
+enableEventLogging :: StackProfilerManager -> STM ()
+enableEventLogging manager = do
+  TVar.writeTVar (isEventlogStarted manager) True
+
+disableEventLogging :: StackProfilerManager -> STM ()
+disableEventLogging manager = do
+  TVar.writeTVar (isEventlogStarted manager) False
+
+enableSampling :: StackProfilerManager -> STM ()
+enableSampling manager = do
+  TVar.writeTVar (isThreadSamplerRunning manager) True
+
+disableSampling :: StackProfilerManager -> STM ()
+disableSampling manager = do
+  TVar.writeTVar (isThreadSamplerRunning manager) False

--- a/ghc-stack-profiler/src/GHC/Stack/Profiler/Stack/Compat.hs
+++ b/ghc-stack-profiler/src/GHC/Stack/Profiler/Stack/Compat.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+
 module GHC.Stack.Profiler.Stack.Compat (
   lookupIpeIdForStackFrame,
 ) where
@@ -22,5 +23,5 @@ lookupIpeIdForStackFrame itbl = do
   -- So, to check whether there is an InfoProv, we first lookup by the 'StgInfoTable' ptr,
   -- i.e. not adjusting for 'TABLES_NEXT_TO_CODE', but if there is an entry, we use the
   -- the struct address, otherwise the decoder will not be able to find the 'InfoProv'.
-  pure $ castPtrToWord64 (infoTableStructPtr itbl) <$ mId
+  pure $! castPtrToWord64 (infoTableStructPtr itbl) <$ mId
 #endif

--- a/ghc-stack-profiler/src/GHC/Stack/Profiler/Stack/Decode.hs
+++ b/ghc-stack-profiler/src/GHC/Stack/Profiler/Stack/Decode.hs
@@ -1,24 +1,25 @@
 {-# LANGUAGE MagicHash #-}
+
 module GHC.Stack.Profiler.Stack.Decode (
   decodeStackWithIpProvId,
 ) where
 
-import Unsafe.Coerce (unsafeCoerce)
 import Data.Maybe (catMaybes)
 import qualified Data.Text as Text
 import Data.Typeable (cast)
+import Unsafe.Coerce (unsafeCoerce)
 
-import GHC.Stack.Annotation.Experimental.Compat
-import GHC.Stack.CloneStack (StackSnapshot(..))
 import GHC.Internal.ClosureTypes.Compat
 import GHC.Internal.Stack.Constants.Compat
 import GHC.Internal.Stack.Decode.Compat as Decode
 import GHC.Internal.Stack.Types
+import GHC.Stack.Annotation.Experimental.Compat
+import GHC.Stack.CloneStack (StackSnapshot (..))
 
 import GHC.Exts.Heap.InfoTable.Types
 
-import GHC.Stack.Profiler.Core.ThreadSample
 import GHC.Stack.Profiler.Core.Eventlog
+import GHC.Stack.Profiler.Core.ThreadSample
 import GHC.Stack.Profiler.Core.Util
 import GHC.Stack.Profiler.Stack.Compat (lookupIpeIdForStackFrame)
 
@@ -27,19 +28,20 @@ decodeStackWithIpProvId (StackSnapshot stack#) = do
   info <- getInfoTableForStack stack#
   case tipe info of
     STACK -> do
-      let sfls = stackFrameLocations stack#
+      let
+        sfls = stackFrameLocations stack#
       stack' <- stackFrameLocationItems sfls
       pure stack'
     _ -> error $ "Expected STACK closure, got " ++ show info
-  where
-    stackFrameLocations :: StackSnapshot# -> [StackFrameLocation]
-    stackFrameLocations s# =
-      stackHead s#
-        : go (advanceStackFrameLocation (stackHead s#))
-      where
-        go :: Maybe StackFrameLocation -> [StackFrameLocation]
-        go Nothing = []
-        go (Just r) = r : go (advanceStackFrameLocation r)
+ where
+  stackFrameLocations :: StackSnapshot# -> [StackFrameLocation]
+  stackFrameLocations s# =
+    stackHead s#
+      : go (advanceStackFrameLocation (stackHead s#))
+   where
+    go :: Maybe StackFrameLocation -> [StackFrameLocation]
+    go Nothing = []
+    go (Just r) = r : go (advanceStackFrameLocation r)
 
 stackFrameLocationItems :: [StackFrameLocation] -> IO [StackItem]
 stackFrameLocationItems frames =
@@ -50,26 +52,29 @@ stackFrameLocationItem (StackSnapshot stack#, index) = do
   stackItbl <- getInfoTableOnStack stack# index
   case tipe (infoTable stackItbl) of
     ANN_FRAME ->
-      let Box annotation = getClosureBox stack# (index + offsetStgAnnFrameAnn)
-       in pure $ stackAnnotationToStackItem (unsafeCoerce annotation)
+      let
+        Box annotation = getClosureBox stack# (index + offsetStgAnnFrameAnn)
+      in
+        pure $ stackAnnotationToStackItem (unsafeCoerce annotation)
     _ ->
       fmap (IpeId . MkIpeId) <$> lookupIpeIdForStackFrame stackItbl
 
 stackAnnotationToStackItem :: SomeStackAnnotation -> Maybe StackItem
-stackAnnotationToStackItem = \ case
+stackAnnotationToStackItem = \case
   SomeStackAnnotation ann ->
     case cast ann of
       Just (CallStackAnnotation cs) ->
         case getCallStack cs of
           [] -> Nothing
-          ((name, sourceLoc):_) ->
-            Just $ SourceLocation $ MkSourceLocation
-              { line = intToWord32 $ srcLocStartLine sourceLoc
-              , column = intToWord32 $ srcLocStartCol sourceLoc
-              , functionName = Text.pack $ name
-              , fileName = Text.pack $ srcLocFile sourceLoc
-              }
-
+          ((name, sourceLoc) : _) ->
+            Just $
+              SourceLocation $
+                MkSourceLocation
+                  { line = intToWord32 $ srcLocStartLine sourceLoc
+                  , column = intToWord32 $ srcLocStartCol sourceLoc
+                  , functionName = Text.pack $ name
+                  , fileName = Text.pack $ srcLocFile sourceLoc
+                  }
       Nothing -> case cast ann of
         Just (StringAnnotation msg) ->
           Just $ UserMessage msg

--- a/ghc-stack-profiler/src/GHC/Stack/Profiler/SymbolTable.hs
+++ b/ghc-stack-profiler/src/GHC/Stack/Profiler/SymbolTable.hs
@@ -1,0 +1,37 @@
+module GHC.Stack.Profiler.SymbolTable (
+  -- * 'StackSymbolTable' type
+  StackSymbolTable,
+  emptySymbolTable,
+  emptySymbolTableIO,
+  readSymbolTable,
+  writeSymbolTable,
+) where
+
+import Control.Concurrent.STM
+import GHC.Generics (Generic)
+import GHC.Stack.Profiler.Core.SymbolTable
+
+-- | A @'SymbolTableWriter' 'MapTable'@ guarded by a lock for mutable, concurrent access.
+--
+-- The lock is an 'MVar', but this is considered an implementation detail that may change without warning.
+newtype StackSymbolTable = MkStackSymbolTable
+  { writerSymbolTable :: TVar (SymbolTableWriter MapTable)
+  }
+  deriving (Generic, Eq)
+
+-- | Create an empty 'StackSymbolTable'
+emptySymbolTableIO :: IO StackSymbolTable
+emptySymbolTableIO = atomically emptySymbolTable
+
+emptySymbolTable :: STM StackSymbolTable
+emptySymbolTable =
+  MkStackSymbolTable
+    <$> newTVar emptyMapSymbolTableWriter
+
+readSymbolTable :: StackSymbolTable -> STM (SymbolTableWriter MapTable)
+readSymbolTable =
+  readTVar . writerSymbolTable
+
+writeSymbolTable :: SymbolTableWriter MapTable -> StackSymbolTable -> STM ()
+writeSymbolTable newWriterTbl symTbl =
+  writeTVar (writerSymbolTable symTbl) newWriterTbl


### PR DESCRIPTION
`eventlog-socket` added support for lifecycle hooks.
These hooks allow us to send eventlog messages when a client opens
the connection.
For example, when a new client opens a connection, all eventlog
initialisation events are sent, informing the user what kind of events
may be sent.

This works great for the GHC eventlog, but `ghc-stack-profiler` eventlog
messages also have initialisation messages! In particular, mappings from
Ids to concrete data, such as strings or source locations. These events
are created ad-hoc and sent when new values are encountered.

If a client connects at a later point, there is no way to get the
existing mapping from Id to the stack data, causing corrupted and
incomplete profiles.

We fix this by adding support for `eventlog-socket`'s lifecycle hooks in
`ghc-stack-profiler`.
For that, we need to make sure that we acquire a lock when writing
eventlog messages, and then reconstructing the initialisation messages
which declare what mappings the user can expect.

For the implementation, we abstract the `StackSymbolTable` which hides
the details of the lock and provide utility functions that client code
can use without worrying about the locking mechanism.